### PR TITLE
fix: windows linux tray behaviour

### DIFF
--- a/.changeset/calm-fireants-pretend.md
+++ b/.changeset/calm-fireants-pretend.md
@@ -1,0 +1,7 @@
+---
+'renterd': patch
+'walletd': patch
+'hostd': patch
+---
+
+Fixed an issue where multiple instances of the app could be started on Windows.

--- a/.changeset/fifty-beds-cheer.md
+++ b/.changeset/fifty-beds-cheer.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+Left-clicking the tray icon on Windows and Linux now opens or focuses the main window.

--- a/hostd/main/index.ts
+++ b/hostd/main/index.ts
@@ -9,73 +9,77 @@ import { startup } from './startup'
 import { prepareNext } from './next'
 import { UpdateSourceType, updateElectronApp } from 'update-electron-app'
 
-// Auto updates
-updateElectronApp({
-  updateSource: {
-    type: UpdateSourceType.StaticStorage,
-    baseUrl: `https://releases.s3.sia.tools/hostd/${process.platform}/${process.arch}`,
-  },
-})
-
-initIpc()
-
-app.on('ready', async () => {
-  await prepareNext('./renderer')
-  initWindow()
-  initTray()
-  initShortcuts()
-  startup()
-})
-
-// Emitted after app.quit is called and before windows are closed.
-app.on('before-quit', async (event?: { preventDefault: () => void }) => {
-  if (!state.isQuitting) {
-    // Events do not support waiting for asynchronous operations to complete.
-    // Instead we cancel the quit event with preventDefault, call quitDaemonAndApp,
-    // and then call app.quit() again to atually quit the app. After the second
-    // call to app.quit(), isQuitting will be set to true, and the app will quit.
-    event?.preventDefault()
-    await quitDaemonAndApp()
-    app.quit()
-  }
-})
-
-// https://www.electronjs.org/docs/latest/api/app#event-before-quit
-// When restarting from an automatic update before-quit is
-// not called **before** all windows are closed, so we must instead
-// use this autoUpdater event to call quitDaemonAndApp.
-autoUpdater.on(
-  'before-quit-for-update',
-  async (event?: { preventDefault: () => void }) => {
-    if (!state.isQuitting) {
-      event?.preventDefault()
-      await quitDaemonAndApp()
-      autoUpdater.quitAndInstall()
-    }
-  }
-)
-
-app.on('will-quit', async () => {
-  // Unregister the shortcut when the application is about to quit.
-  globalShortcut.unregisterAll()
-
-  // https://www.electronjs.org/docs/latest/api/app#event-before-quit
-  // Note: On Windows, 'before-quit' event will not be emitted if the app is
-  // closed due to a shutdown/restart of the system or a user logout.
-  // Adding this extra attempt to quit the app for windows, but there is no
-  // guarantee that this will run before the app is killed.
-  if (!state.isQuitting) {
-    await quitDaemonAndApp()
-  }
-})
-
-// The default behavior of this event is to quit the app when all windows are closed.
-// Because closeMainWindow does not actually close the window, this event is
-// never used to quit the app, overriding it with a no-op to make this clear.
-app.on('window-all-closed', () => {})
-
 // Windows: https://github.com/mongodb-js/electron-squirrel-startup
 if (require('electron-squirrel-startup')) {
+  app.quit()
+}
+
+if (app.requestSingleInstanceLock()) {
+  // Auto updates
+  updateElectronApp({
+    updateSource: {
+      type: UpdateSourceType.StaticStorage,
+      baseUrl: `https://releases.s3.sia.tools/hostd/${process.platform}/${process.arch}`,
+    },
+  })
+
+  initIpc()
+
+  app.on('ready', async () => {
+    await prepareNext('./renderer')
+    initWindow()
+    initTray()
+    initShortcuts()
+    startup()
+  })
+
+  // Emitted after app.quit is called and before windows are closed.
+  app.on('before-quit', async (event?: { preventDefault: () => void }) => {
+    if (!state.isQuitting) {
+      // Events do not support waiting for asynchronous operations to complete.
+      // Instead we cancel the quit event with preventDefault, call quitDaemonAndApp,
+      // and then call app.quit() again to atually quit the app. After the second
+      // call to app.quit(), isQuitting will be set to true, and the app will quit.
+      event?.preventDefault()
+      await quitDaemonAndApp()
+      app.quit()
+    }
+  })
+
+  // https://www.electronjs.org/docs/latest/api/app#event-before-quit
+  // When restarting from an automatic update before-quit is
+  // not called **before** all windows are closed, so we must instead
+  // use this autoUpdater event to call quitDaemonAndApp.
+  autoUpdater.on(
+    'before-quit-for-update',
+    async (event?: { preventDefault: () => void }) => {
+      if (!state.isQuitting) {
+        event?.preventDefault()
+        await quitDaemonAndApp()
+        autoUpdater.quitAndInstall()
+      }
+    }
+  )
+
+  app.on('will-quit', async () => {
+    // Unregister the shortcut when the application is about to quit.
+    globalShortcut.unregisterAll()
+
+    // https://www.electronjs.org/docs/latest/api/app#event-before-quit
+    // Note: On Windows, 'before-quit' event will not be emitted if the app is
+    // closed due to a shutdown/restart of the system or a user logout.
+    // Adding this extra attempt to quit the app for windows, but there is no
+    // guarantee that this will run before the app is killed.
+    if (!state.isQuitting) {
+      await quitDaemonAndApp()
+    }
+  })
+
+  // The default behavior of this event is to quit the app when all windows are closed.
+  // Because closeMainWindow does not actually close the window, this event is
+  // never used to quit the app, overriding it with a no-op to make this clear.
+  app.on('window-all-closed', () => {})
+} else {
   app.quit()
 }
 

--- a/hostd/main/tray.ts
+++ b/hostd/main/tray.ts
@@ -11,20 +11,39 @@ export function initTray() {
   const trayContextMenu = Menu.buildFromTemplate([
     {
       label: 'Configure',
-      click: function () {
+      click: () => {
         if (system.isDarwin) {
           app.dock.show()
         }
-        state.mainWindow?.show()
+        showWindow()
       },
     },
     {
       label: 'Quit',
-      click: function () {
+      click: () => {
         app.quit()
       },
     },
   ])
   state.tray.setToolTip('hostd')
   state.tray.setContextMenu(trayContextMenu)
+  // On Windows and Linux the context menu is triggered with a right-click.
+  // This makes left-click open the main window.
+  state.tray.on('click', () => {
+    if (system.isDarwin) {
+      return
+    }
+    showWindow()
+  })
+}
+
+function showWindow() {
+  if (state.mainWindow) {
+    if (state.mainWindow.isMinimized()) {
+      state.mainWindow.restore()
+    }
+    state.mainWindow.isVisible()
+      ? state.mainWindow.focus()
+      : state.mainWindow.show()
+  }
 }

--- a/renterd/main/index.ts
+++ b/renterd/main/index.ts
@@ -9,73 +9,77 @@ import { startup } from './startup'
 import { prepareNext } from './next'
 import { UpdateSourceType, updateElectronApp } from 'update-electron-app'
 
-// Auto updates
-updateElectronApp({
-  updateSource: {
-    type: UpdateSourceType.StaticStorage,
-    baseUrl: `https://releases.s3.sia.tools/renterd/${process.platform}/${process.arch}`,
-  },
-})
-
-initIpc()
-
-app.on('ready', async () => {
-  await prepareNext('./renderer')
-  initWindow()
-  initTray()
-  initShortcuts()
-  startup()
-})
-
-// Emitted after app.quit is called and before windows are closed.
-app.on('before-quit', async (event?: { preventDefault: () => void }) => {
-  if (!state.isQuitting) {
-    // Events do not support waiting for asynchronous operations to complete.
-    // Instead we cancel the quit event with preventDefault, call quitDaemonAndApp,
-    // and then call app.quit() again to atually quit the app. After the second
-    // call to app.quit(), isQuitting will be set to true, and the app will quit.
-    event?.preventDefault()
-    await quitDaemonAndApp()
-    app.quit()
-  }
-})
-
-// https://www.electronjs.org/docs/latest/api/app#event-before-quit
-// When restarting from an automatic update before-quit is
-// not called **before** all windows are closed, so we must instead
-// use this autoUpdater event to call quitDaemonAndApp.
-autoUpdater.on(
-  'before-quit-for-update',
-  async (event?: { preventDefault: () => void }) => {
-    if (!state.isQuitting) {
-      event?.preventDefault()
-      await quitDaemonAndApp()
-      autoUpdater.quitAndInstall()
-    }
-  }
-)
-
-app.on('will-quit', async () => {
-  // Unregister the shortcut when the application is about to quit.
-  globalShortcut.unregisterAll()
-
-  // https://www.electronjs.org/docs/latest/api/app#event-before-quit
-  // Note: On Windows, 'before-quit' event will not be emitted if the app is
-  // closed due to a shutdown/restart of the system or a user logout.
-  // Adding this extra attempt to quit the app for windows, but there is no
-  // guarantee that this will run before the app is killed.
-  if (!state.isQuitting) {
-    await quitDaemonAndApp()
-  }
-})
-
-// The default behavior of this event is to quit the app when all windows are closed.
-// Because closeMainWindow does not actually close the window, this event is
-// never used to quit the app, overriding it with a no-op to make this clear.
-app.on('window-all-closed', () => {})
-
 // Windows: https://github.com/mongodb-js/electron-squirrel-startup
 if (require('electron-squirrel-startup')) {
+  app.quit()
+}
+
+if (app.requestSingleInstanceLock()) {
+  // Auto updates
+  updateElectronApp({
+    updateSource: {
+      type: UpdateSourceType.StaticStorage,
+      baseUrl: `https://releases.s3.sia.tools/renterd/${process.platform}/${process.arch}`,
+    },
+  })
+
+  initIpc()
+
+  app.on('ready', async () => {
+    await prepareNext('./renderer')
+    initWindow()
+    initTray()
+    initShortcuts()
+    startup()
+  })
+
+  // Emitted after app.quit is called and before windows are closed.
+  app.on('before-quit', async (event?: { preventDefault: () => void }) => {
+    if (!state.isQuitting) {
+      // Events do not support waiting for asynchronous operations to complete.
+      // Instead we cancel the quit event with preventDefault, call quitDaemonAndApp,
+      // and then call app.quit() again to atually quit the app. After the second
+      // call to app.quit(), isQuitting will be set to true, and the app will quit.
+      event?.preventDefault()
+      await quitDaemonAndApp()
+      app.quit()
+    }
+  })
+
+  // https://www.electronjs.org/docs/latest/api/app#event-before-quit
+  // When restarting from an automatic update before-quit is
+  // not called **before** all windows are closed, so we must instead
+  // use this autoUpdater event to call quitDaemonAndApp.
+  autoUpdater.on(
+    'before-quit-for-update',
+    async (event?: { preventDefault: () => void }) => {
+      if (!state.isQuitting) {
+        event?.preventDefault()
+        await quitDaemonAndApp()
+        autoUpdater.quitAndInstall()
+      }
+    }
+  )
+
+  app.on('will-quit', async () => {
+    // Unregister the shortcut when the application is about to quit.
+    globalShortcut.unregisterAll()
+
+    // https://www.electronjs.org/docs/latest/api/app#event-before-quit
+    // Note: On Windows, 'before-quit' event will not be emitted if the app is
+    // closed due to a shutdown/restart of the system or a user logout.
+    // Adding this extra attempt to quit the app for windows, but there is no
+    // guarantee that this will run before the app is killed.
+    if (!state.isQuitting) {
+      await quitDaemonAndApp()
+    }
+  })
+
+  // The default behavior of this event is to quit the app when all windows are closed.
+  // Because closeMainWindow does not actually close the window, this event is
+  // never used to quit the app, overriding it with a no-op to make this clear.
+  app.on('window-all-closed', () => {})
+} else {
   app.quit()
 }
 

--- a/renterd/main/tray.ts
+++ b/renterd/main/tray.ts
@@ -11,7 +11,7 @@ export function initTray() {
   const trayContextMenu = Menu.buildFromTemplate([
     {
       label: 'Configure',
-      click: function () {
+      click: () => {
         if (system.isDarwin) {
           app.dock.show()
         }
@@ -20,11 +20,26 @@ export function initTray() {
     },
     {
       label: 'Quit',
-      click: function () {
+      click: () => {
         app.quit()
       },
     },
   ])
   state.tray.setToolTip('hostd')
   state.tray.setContextMenu(trayContextMenu)
+  // On Windows and Linux the context menu is triggered with a right-click.
+  // This makes left-click open the main window.
+  state.tray.on('click', () => {
+    if (system.isDarwin) {
+      return
+    }
+    if (state.mainWindow) {
+      if (state.mainWindow.isMinimized()) {
+        state.mainWindow.restore()
+      }
+      state.mainWindow.isVisible()
+        ? state.mainWindow.focus()
+        : state.mainWindow.show()
+    }
+  })
 }

--- a/walletd/main/index.ts
+++ b/walletd/main/index.ts
@@ -9,73 +9,77 @@ import { startup } from './startup'
 import { prepareNext } from './next'
 import { UpdateSourceType, updateElectronApp } from 'update-electron-app'
 
-// Auto updates
-updateElectronApp({
-  updateSource: {
-    type: UpdateSourceType.StaticStorage,
-    baseUrl: `https://releases.s3.sia.tools/walletd/${process.platform}/${process.arch}`,
-  },
-})
-
-initIpc()
-
-app.on('ready', async () => {
-  await prepareNext('./renderer')
-  initWindow()
-  initTray()
-  initShortcuts()
-  startup()
-})
-
-// Emitted after app.quit is called and before windows are closed.
-app.on('before-quit', async (event?: { preventDefault: () => void }) => {
-  if (!state.isQuitting) {
-    // Events do not support waiting for asynchronous operations to complete.
-    // Instead we cancel the quit event with preventDefault, call quitDaemonAndApp,
-    // and then call app.quit() again to atually quit the app. After the second
-    // call to app.quit(), isQuitting will be set to true, and the app will quit.
-    event?.preventDefault()
-    await quitDaemonAndApp()
-    app.quit()
-  }
-})
-
-// https://www.electronjs.org/docs/latest/api/app#event-before-quit
-// When restarting from an automatic update before-quit is
-// not called **before** all windows are closed, so we must instead
-// use this autoUpdater event to call quitDaemonAndApp.
-autoUpdater.on(
-  'before-quit-for-update',
-  async (event?: { preventDefault: () => void }) => {
-    if (!state.isQuitting) {
-      event?.preventDefault()
-      await quitDaemonAndApp()
-      autoUpdater.quitAndInstall()
-    }
-  }
-)
-
-app.on('will-quit', async () => {
-  // Unregister the shortcut when the application is about to quit.
-  globalShortcut.unregisterAll()
-
-  // https://www.electronjs.org/docs/latest/api/app#event-before-quit
-  // Note: On Windows, 'before-quit' event will not be emitted if the app is
-  // closed due to a shutdown/restart of the system or a user logout.
-  // Adding this extra attempt to quit the app for windows, but there is no
-  // guarantee that this will run before the app is killed.
-  if (!state.isQuitting) {
-    await quitDaemonAndApp()
-  }
-})
-
-// The default behavior of this event is to quit the app when all windows are closed.
-// Because closeMainWindow does not actually close the window, this event is
-// never used to quit the app, overriding it with a no-op to make this clear.
-app.on('window-all-closed', () => {})
-
 // Windows: https://github.com/mongodb-js/electron-squirrel-startup
 if (require('electron-squirrel-startup')) {
+  app.quit()
+}
+
+if (app.requestSingleInstanceLock()) {
+  // Auto updates
+  updateElectronApp({
+    updateSource: {
+      type: UpdateSourceType.StaticStorage,
+      baseUrl: `https://releases.s3.sia.tools/walletd/${process.platform}/${process.arch}`,
+    },
+  })
+
+  initIpc()
+
+  app.on('ready', async () => {
+    await prepareNext('./renderer')
+    initWindow()
+    initTray()
+    initShortcuts()
+    startup()
+  })
+
+  // Emitted after app.quit is called and before windows are closed.
+  app.on('before-quit', async (event?: { preventDefault: () => void }) => {
+    if (!state.isQuitting) {
+      // Events do not support waiting for asynchronous operations to complete.
+      // Instead we cancel the quit event with preventDefault, call quitDaemonAndApp,
+      // and then call app.quit() again to atually quit the app. After the second
+      // call to app.quit(), isQuitting will be set to true, and the app will quit.
+      event?.preventDefault()
+      await quitDaemonAndApp()
+      app.quit()
+    }
+  })
+
+  // https://www.electronjs.org/docs/latest/api/app#event-before-quit
+  // When restarting from an automatic update before-quit is
+  // not called **before** all windows are closed, so we must instead
+  // use this autoUpdater event to call quitDaemonAndApp.
+  autoUpdater.on(
+    'before-quit-for-update',
+    async (event?: { preventDefault: () => void }) => {
+      if (!state.isQuitting) {
+        event?.preventDefault()
+        await quitDaemonAndApp()
+        autoUpdater.quitAndInstall()
+      }
+    }
+  )
+
+  app.on('will-quit', async () => {
+    // Unregister the shortcut when the application is about to quit.
+    globalShortcut.unregisterAll()
+
+    // https://www.electronjs.org/docs/latest/api/app#event-before-quit
+    // Note: On Windows, 'before-quit' event will not be emitted if the app is
+    // closed due to a shutdown/restart of the system or a user logout.
+    // Adding this extra attempt to quit the app for windows, but there is no
+    // guarantee that this will run before the app is killed.
+    if (!state.isQuitting) {
+      await quitDaemonAndApp()
+    }
+  })
+
+  // The default behavior of this event is to quit the app when all windows are closed.
+  // Because closeMainWindow does not actually close the window, this event is
+  // never used to quit the app, overriding it with a no-op to make this clear.
+  app.on('window-all-closed', () => {})
+} else {
   app.quit()
 }
 

--- a/walletd/main/tray.ts
+++ b/walletd/main/tray.ts
@@ -11,20 +11,39 @@ export function initTray() {
   const trayContextMenu = Menu.buildFromTemplate([
     {
       label: 'Configure',
-      click: function () {
+      click: () => {
         if (system.isDarwin) {
           app.dock.show()
         }
-        state.mainWindow?.show()
+        showWindow()
       },
     },
     {
       label: 'Quit',
-      click: function () {
+      click: () => {
         app.quit()
       },
     },
   ])
   state.tray.setToolTip('hostd')
   state.tray.setContextMenu(trayContextMenu)
+  // On Windows and Linux the context menu is triggered with a right-click.
+  // This makes left-click open the main window.
+  state.tray.on('click', () => {
+    if (system.isDarwin) {
+      return
+    }
+    showWindow()
+  })
+}
+
+function showWindow() {
+  if (state.mainWindow) {
+    if (state.mainWindow.isMinimized()) {
+      state.mainWindow.restore()
+    }
+    state.mainWindow.isVisible()
+      ? state.mainWindow.focus()
+      : state.mainWindow.show()
+  }
 }


### PR DESCRIPTION
- Left-clicking the tray icon on Windows and Linux now opens or focuses the main window.
