### PR TITLE
fix: refine recovery phrase ux

### DIFF
--- a/.changeset/nine-clouds-change.md
+++ b/.changeset/nine-clouds-change.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+The user experience around recovery phrase generation and re-generation has been refined.

--- a/hostd/renderer/components/SeedField.tsx
+++ b/hostd/renderer/components/SeedField.tsx
@@ -7,6 +7,7 @@ import { SeedLayout } from './SeedLayout'
 
 export function SeedField() {
   const { form, fields, regenerateMnemonic, copySeed } = useConfig()
+  const mnemonic = form.watch('mnemonic')
   return (
     <SeedLayout
       icon={<SeedIcon />}
@@ -26,9 +27,9 @@ export function SeedField() {
         <div className="flex gap-2">
           <Button className="flex-1" onClick={regenerateMnemonic}>
             <Redo16 />
-            Regenerate
+            {mnemonic ? 'Regenerate' : 'Generate'}
           </Button>
-          <Button className="flex-1" onClick={copySeed}>
+          <Button disabled={!mnemonic} className="flex-1" onClick={copySeed}>
             <Copy16 />
             Copy to clipboard
           </Button>

--- a/hostd/renderer/contexts/config/fields.tsx
+++ b/hostd/renderer/contexts/config/fields.tsx
@@ -71,7 +71,7 @@ export function getFields({
         event.currentTarget.select()
       },
       placeholder:
-        'tent small dress shop wealth fantasy wave mobile hint faith skirt derive',
+        'Example: tent small dress shop wealth fantasy wave mobile hint faith skirt derive',
       validation: {
         required: 'required',
         validate: {

--- a/hostd/renderer/contexts/config/index.tsx
+++ b/hostd/renderer/contexts/config/index.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react'
 import {
   triggerErrorToast,
-  useOnInvalid,
   useFormInit,
   useFormServerSynced,
   useFormChangeCount,

--- a/hostd/renderer/contexts/config/useForm.tsx
+++ b/hostd/renderer/contexts/config/useForm.tsx
@@ -46,7 +46,7 @@ export function useForm({ resources }: { resources?: Resources }) {
   }, [setShowHttpPassword])
 
   const copySeed = useCallback(() => {
-    copyToClipboard(mnemonic, 'seed')
+    copyToClipboard(mnemonic, 'recovery phrase')
     form.setValue('hasCopied', true, {
       shouldDirty: true,
       shouldTouch: true,

--- a/renterd/renderer/components/SeedField.tsx
+++ b/renterd/renderer/components/SeedField.tsx
@@ -7,6 +7,7 @@ import { SeedLayout } from './SeedLayout'
 
 export function SeedField() {
   const { form, fields, regenerateMnemonic, copySeed } = useConfig()
+  const mnemonic = form.watch('mnemonic')
   return (
     <SeedLayout
       icon={<SeedIcon />}
@@ -26,9 +27,9 @@ export function SeedField() {
         <div className="flex gap-2">
           <Button className="flex-1" onClick={regenerateMnemonic}>
             <Redo16 />
-            Regenerate
+            {mnemonic ? 'Regenerate' : 'Generate'}
           </Button>
-          <Button className="flex-1" onClick={copySeed}>
+          <Button disabled={!mnemonic} className="flex-1" onClick={copySeed}>
             <Copy16 />
             Copy to clipboard
           </Button>

--- a/renterd/renderer/contexts/config/fields.tsx
+++ b/renterd/renderer/contexts/config/fields.tsx
@@ -64,7 +64,7 @@ export function getFields({
         event.currentTarget.select()
       },
       placeholder:
-        'tent small dress shop wealth fantasy wave mobile hint faith skirt derive',
+        'Example: tent small dress shop wealth fantasy wave mobile hint faith skirt derive',
       validation: {
         required: 'required',
         validate: {

--- a/renterd/renderer/contexts/config/index.tsx
+++ b/renterd/renderer/contexts/config/index.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react'
 import {
   triggerErrorToast,
-  useOnInvalid,
   useFormInit,
   useFormServerSynced,
   useFormChangeCount,

--- a/renterd/renderer/contexts/config/useForm.tsx
+++ b/renterd/renderer/contexts/config/useForm.tsx
@@ -46,7 +46,7 @@ export function useForm({ resources }: { resources?: Resources }) {
   }, [setShowHttpPassword])
 
   const copySeed = useCallback(() => {
-    copyToClipboard(mnemonic, 'seed')
+    copyToClipboard(mnemonic, 'recovery phrase')
     form.setValue('hasCopied', true, {
       shouldDirty: true,
       shouldTouch: true,

--- a/walletd/renderer/contexts/config/index.tsx
+++ b/walletd/renderer/contexts/config/index.tsx
@@ -3,7 +3,6 @@
 import { createContext, useCallback, useContext, useMemo } from 'react'
 import {
   triggerErrorToast,
-  useOnInvalid,
   useFormInit,
   useFormServerSynced,
   useFormChangeCount,


### PR DESCRIPTION
- The user experience around recovery phrase generation and re-generation has been refined.
- Also: using this version change and subsequent release to test auto-updates on Windows, Ubuntu, and Debian.

<img width="531" alt="Screenshot 2024-07-02 at 11 05 08 AM" src="https://github.com/SiaFoundation/desktop/assets/1412796/7affeccd-e842-4d69-b1bb-72d9bbd2e174">
<img width="521" alt="Screenshot 2024-07-02 at 11 05 15 AM" src="https://github.com/SiaFoundation/desktop/assets/1412796/e0401190-d635-4c4a-9701-790123d7105e">

