### PR TITLE
fix: seed change and copy ux

### DIFF
--- a/.changeset/dull-bobcats-prove.md
+++ b/.changeset/dull-bobcats-prove.md
@@ -1,0 +1,6 @@
+---
+'renterd': patch
+'hostd': patch
+---
+
+Copying the recovery phrase value is now only required if the value has changed.

--- a/.changeset/flat-horses-play.md
+++ b/.changeset/flat-horses-play.md
@@ -1,0 +1,6 @@
+---
+'renterd': minor
+'hostd': minor
+---
+
+The recovery phrase is now displayed in a locked state if a saved value exists. Closes https://github.com/SiaFoundation/desktop/issues/67

--- a/.changeset/stupid-parrots-bathe.md
+++ b/.changeset/stupid-parrots-bathe.md
@@ -1,0 +1,6 @@
+---
+'renterd': minor
+'hostd': minor
+---
+
+Recovery phrase and password visibility selections no longer persist between app start, they now reset to hidden.

--- a/.changeset/tough-ghosts-jog.md
+++ b/.changeset/tough-ghosts-jog.md
@@ -1,0 +1,6 @@
+---
+'renterd': minor
+'hostd': minor
+---
+
+Regenerating the recovery phrase now warns the user and asks for confirmation. Closes https://github.com/SiaFoundation/desktop/issues/67

--- a/hostd/renderer/components/SeedField.tsx
+++ b/hostd/renderer/components/SeedField.tsx
@@ -1,13 +1,68 @@
 'use client'
 
-import { Button, FieldText, FieldTextArea } from '@siafoundation/design-system'
-import { Copy16, Redo16, SeedIcon } from '@siafoundation/react-icons'
+import {
+  Button,
+  ControlGroup,
+  FieldLabelAndError,
+  FieldText,
+  FieldTextArea,
+  Text,
+} from '@siafoundation/design-system'
+import {
+  Copy16,
+  Edit16,
+  Locked16,
+  Redo16,
+  SeedIcon,
+} from '@siafoundation/react-icons'
 import { useConfig } from '../contexts/config'
 import { SeedLayout } from './SeedLayout'
 
 export function SeedField() {
-  const { form, fields, regenerateMnemonic, copySeed } = useConfig()
+  const {
+    form,
+    fields,
+    regenerateMnemonic,
+    mnemonicReadOnly,
+    setMnemonicReadOnly,
+    copyMnemonic,
+  } = useConfig()
   const mnemonic = form.watch('mnemonic')
+  const { error } = form.getFieldState('mnemonic')
+
+  if (mnemonicReadOnly) {
+    return (
+      <div className="flex flex-col gap-1">
+        <FieldLabelAndError
+          title="Recovery phrase"
+          form={form}
+          name="mnemonic"
+        />
+        <ControlGroup>
+          <Button className="flex-1" state="waiting">
+            <Text color="subtle">Recovery phrase is configured</Text>
+          </Button>
+          <Button
+            tip="Copy recovery phrase to clipboard"
+            onClick={copyMnemonic}
+          >
+            <Copy16 />
+          </Button>
+          <Button
+            tip="Change recovery phrase"
+            onClick={() => setMnemonicReadOnly(false)}
+          >
+            <Edit16 />
+          </Button>
+        </ControlGroup>
+        {/* field is not visible but registering the field is required for react-hook-form to validate */}
+        <div className="hidden">
+          <FieldText form={form} fields={fields} name="mnemonic" />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <SeedLayout
       icon={<SeedIcon />}
@@ -25,13 +80,31 @@ export function SeedField() {
           <FieldTextArea form={form} fields={fields} name="mnemonic" />
         )}
         <div className="flex gap-2">
-          <Button className="flex-1" onClick={regenerateMnemonic}>
+          <Button
+            className="flex-1"
+            onClick={regenerateMnemonic}
+            tip="Generate new recovery phrase"
+          >
             <Redo16 />
             {mnemonic ? 'Regenerate' : 'Generate'}
           </Button>
-          <Button disabled={!mnemonic} className="flex-1" onClick={copySeed}>
+          <Button
+            disabled={!mnemonic}
+            className="flex-1"
+            onClick={copyMnemonic}
+            tip="Copy recovery phrase to clipboard"
+          >
             <Copy16 />
-            Copy to clipboard
+            Copy
+          </Button>
+          <Button
+            disabled={!mnemonic || !!error}
+            className="flex-1"
+            onClick={() => setMnemonicReadOnly(true)}
+            tip="Lock the recovery phrase input field"
+          >
+            <Locked16 />
+            Lock
           </Button>
         </div>
       </div>

--- a/hostd/renderer/contexts/config/fields.tsx
+++ b/hostd/renderer/contexts/config/fields.tsx
@@ -79,19 +79,12 @@ export function getFields({
             const valid = bip39.validateMnemonic(value as string)
             return valid || 'should be 12 word BIP39 mnemonic'
           },
-          copied: (_, values) =>
-            values.hasCopied || 'Copy recovery phrase to continue',
         },
       },
     },
     autoOpenWebUI: {
       type: 'boolean',
       title: 'Automatically open the web UI on startup',
-      validation: {},
-    },
-    hasCopied: {
-      type: 'boolean',
-      title: '',
       validation: {},
     },
     httpAddress: {

--- a/hostd/renderer/contexts/config/index.tsx
+++ b/hostd/renderer/contexts/config/index.tsx
@@ -6,6 +6,7 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useState,
 } from 'react'
 import {
   triggerErrorToast,
@@ -50,7 +51,11 @@ function useConfigMain() {
     showAdvanced,
     setShowAdvanced,
     regenerateMnemonic,
-    copySeed,
+    copyMnemonic,
+    hasCopiedMnemonic,
+    savedMnemonic,
+    mnemonicReadOnly,
+    setMnemonicReadOnly,
   } = useForm({
     resources,
   })
@@ -100,6 +105,12 @@ function useConfigMain() {
   const { startDaemon } = useDaemon()
   const onValid = useCallback(
     async (values: ConfigValues) => {
+      if (savedMnemonic !== values.mnemonic && !hasCopiedMnemonic) {
+        triggerErrorToast({
+          title: 'Please copy and securely store the recovery phrase',
+        })
+        return
+      }
       const firstTimeConfiguring = notConfiguredYet
       const saveConfig = await window.electron.saveConfig(transformUp(values))
       if (saveConfig.error) {
@@ -123,21 +134,15 @@ function useConfigMain() {
 
   const onSubmit = useMemo(() => form.handleSubmit(onValid), [form, onValid])
 
-  useEffect(() => {
-    if (remoteValues) {
-      if (remoteValues.mnemonic != '') {
-        form.setValue('hasCopied', true)
-      }
-    }
-  }, [remoteValues])
-
   return {
     notConfiguredYet,
     form,
     fields,
     isConfigured,
     changeCount,
-    copySeed,
+    copyMnemonic,
+    mnemonicReadOnly,
+    setMnemonicReadOnly,
     regenerateMnemonic,
     onSubmit,
     revalidateAndResetForm,

--- a/hostd/renderer/contexts/config/transform.ts
+++ b/hostd/renderer/contexts/config/transform.ts
@@ -15,7 +15,6 @@ export function transformDown({
     dataDir: config.directory || defaultDataPath,
     mnemonic: config.recoveryPhrase,
     autoOpenWebUI: config.autoOpenWebUI,
-    hasCopied: false,
     httpAddress: config.http.address,
     httpPassword: config.http.password,
     consensusGatewayAddress: config.consensus.gatewayAddress,

--- a/hostd/renderer/contexts/config/types.ts
+++ b/hostd/renderer/contexts/config/types.ts
@@ -2,7 +2,6 @@ export const defaultValues = {
   name: '',
   dataDir: '',
   mnemonic: '',
-  hasCopied: false,
   autoOpenWebUI: true,
   httpAddress: 'localhost:9980',
   httpPassword: '',

--- a/hostd/renderer/contexts/config/useForm.tsx
+++ b/hostd/renderer/contexts/config/useForm.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useCallback, useMemo } from 'react'
+import { useCallback, useEffect, useMemo, useState } from 'react'
 import useLocalStorageState from 'use-local-storage-state'
 import { useForm as useHookForm } from 'react-hook-form'
 import { defaultValues } from './types'
@@ -23,48 +23,61 @@ export function useForm({ resources }: { resources?: Resources }) {
       defaultValue: false,
     }
   )
-  const [showMnemonic, setShowMnemonic] = useLocalStorageState<boolean>(
-    'v0/config/showMnemonic',
-    {
-      defaultValue: false,
-    }
+  const [showMnemonic, setShowMnemonic] = useState(false)
+
+  const savedMnemonic = useMemo(
+    () => resources?.config?.data?.recoveryPhrase,
+    [resources]
   )
+
+  const [mnemonicReadOnly, setMnemonicReadOnly] = useState(false)
+
+  // Reset the mnemonicReadOnly state whenever the saved mnemonic changes.
+  useEffect(() => {
+    if (savedMnemonic) {
+      setMnemonicReadOnly(true)
+    }
+  }, [savedMnemonic])
 
   const toggleShowMnemonic = useCallback(() => {
     setShowMnemonic((showMnemonic) => !showMnemonic)
   }, [setShowMnemonic])
 
-  const [showHttpPassword, setShowHttpPassword] = useLocalStorageState<boolean>(
-    'v0/config/showHttpPassword',
-    {
-      defaultValue: false,
-    }
-  )
+  const [showHttpPassword, setShowHttpPassword] = useState(false)
 
   const toggleShowHttpPassword = useCallback(() => {
     setShowHttpPassword((showHttpPassword) => !showHttpPassword)
   }, [setShowHttpPassword])
 
-  const copySeed = useCallback(() => {
+  const [hasCopiedMnemonic, setHasCopiedMnemonic] = useState(false)
+  const copyMnemonic = useCallback(() => {
     copyToClipboard(mnemonic, 'recovery phrase')
-    form.setValue('hasCopied', true, {
-      shouldDirty: true,
-      shouldTouch: true,
-      shouldValidate: true,
-    })
+    setHasCopiedMnemonic(true)
     form.clearErrors(['mnemonic'])
   }, [mnemonic, form])
 
+  // Reset the copied check whenever the mnemonic changes.
+  useEffect(() => {
+    setHasCopiedMnemonic(false)
+  }, [mnemonic])
+
   const regenerateMnemonic = useCallback(async () => {
     try {
+      if (savedMnemonic) {
+        const yes = confirm(
+          'Are you sure you want to regenerate the recovery phrase? The current recovery phrase will be replaced with a new one.'
+        )
+        if (!yes) {
+          return
+        }
+      }
       const mnemonic = bip39.generateMnemonic()
-      form.setValue('hasCopied', false)
       form.setValue('mnemonic', mnemonic, {
         shouldDirty: true,
         shouldTouch: true,
         shouldValidate: true,
       })
-      form.clearErrors(['hasCopied', 'mnemonic'])
+      form.clearErrors(['mnemonic'])
     } catch (e) {
       form.setError('mnemonic', {
         message: e as string,
@@ -84,7 +97,7 @@ export function useForm({ resources }: { resources?: Resources }) {
     [
       dataDir,
       resources,
-      copySeed,
+      copyMnemonic,
       toggleShowMnemonic,
       showMnemonic,
       toggleShowHttpPassword,
@@ -99,7 +112,11 @@ export function useForm({ resources }: { resources?: Resources }) {
     setShowAdvanced,
     dataDir,
     mnemonic,
-    copySeed,
+    copyMnemonic,
+    hasCopiedMnemonic,
     regenerateMnemonic,
+    mnemonicReadOnly,
+    savedMnemonic,
+    setMnemonicReadOnly,
   }
 }

--- a/renterd/renderer/components/SeedField.tsx
+++ b/renterd/renderer/components/SeedField.tsx
@@ -1,13 +1,68 @@
 'use client'
 
-import { Button, FieldText, FieldTextArea } from '@siafoundation/design-system'
-import { Copy16, Redo16, SeedIcon } from '@siafoundation/react-icons'
+import {
+  Button,
+  ControlGroup,
+  FieldLabelAndError,
+  FieldText,
+  FieldTextArea,
+  Text,
+} from '@siafoundation/design-system'
+import {
+  Copy16,
+  Edit16,
+  Locked16,
+  Redo16,
+  SeedIcon,
+} from '@siafoundation/react-icons'
 import { useConfig } from '../contexts/config'
 import { SeedLayout } from './SeedLayout'
 
 export function SeedField() {
-  const { form, fields, regenerateMnemonic, copySeed } = useConfig()
+  const {
+    form,
+    fields,
+    regenerateMnemonic,
+    mnemonicReadOnly,
+    setMnemonicReadOnly,
+    copyMnemonic,
+  } = useConfig()
   const mnemonic = form.watch('mnemonic')
+  const { error } = form.getFieldState('mnemonic')
+
+  if (mnemonicReadOnly) {
+    return (
+      <div className="flex flex-col gap-1">
+        <FieldLabelAndError
+          title="Recovery phrase"
+          form={form}
+          name="mnemonic"
+        />
+        <ControlGroup>
+          <Button className="flex-1" state="waiting">
+            <Text color="subtle">Recovery phrase is configured</Text>
+          </Button>
+          <Button
+            tip="Copy recovery phrase to clipboard"
+            onClick={copyMnemonic}
+          >
+            <Copy16 />
+          </Button>
+          <Button
+            tip="Change recovery phrase"
+            onClick={() => setMnemonicReadOnly(false)}
+          >
+            <Edit16 />
+          </Button>
+        </ControlGroup>
+        {/* field is not visible but registering the field is required for react-hook-form to validate */}
+        <div className="hidden">
+          <FieldText form={form} fields={fields} name="mnemonic" />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <SeedLayout
       icon={<SeedIcon />}
@@ -25,13 +80,31 @@ export function SeedField() {
           <FieldTextArea form={form} fields={fields} name="mnemonic" />
         )}
         <div className="flex gap-2">
-          <Button className="flex-1" onClick={regenerateMnemonic}>
+          <Button
+            className="flex-1"
+            onClick={regenerateMnemonic}
+            tip="Generate new recovery phrase"
+          >
             <Redo16 />
             {mnemonic ? 'Regenerate' : 'Generate'}
           </Button>
-          <Button disabled={!mnemonic} className="flex-1" onClick={copySeed}>
+          <Button
+            disabled={!mnemonic}
+            className="flex-1"
+            onClick={copyMnemonic}
+            tip="Copy recovery phrase to clipboard"
+          >
             <Copy16 />
-            Copy to clipboard
+            Copy
+          </Button>
+          <Button
+            disabled={!mnemonic || !!error}
+            className="flex-1"
+            onClick={() => setMnemonicReadOnly(true)}
+            tip="Lock the recovery phrase input field"
+          >
+            <Locked16 />
+            Lock
           </Button>
         </div>
       </div>

--- a/renterd/renderer/contexts/config/fields.tsx
+++ b/renterd/renderer/contexts/config/fields.tsx
@@ -72,19 +72,12 @@ export function getFields({
             const valid = bip39.validateMnemonic(value as string)
             return valid || 'should be 12 word BIP39 mnemonic'
           },
-          copied: (_, values: ConfigValues) =>
-            values.hasCopied || 'Copy recovery phrase to continue',
         },
       },
     },
     autoOpenWebUI: {
       type: 'boolean',
       title: 'Automatically open the web UI on startup',
-      validation: {},
-    },
-    hasCopied: {
-      type: 'boolean',
-      title: '',
       validation: {},
     },
     httpAddress: {

--- a/renterd/renderer/contexts/config/transform.ts
+++ b/renterd/renderer/contexts/config/transform.ts
@@ -12,7 +12,6 @@ export function transformDown({
 }): ConfigValues {
   return {
     mnemonic: config.seed,
-    hasCopied: false,
     autoOpenWebUI: config.autoOpenWebUI,
     dataDir: config.directory || defaultDataPath,
     logLevel: config.log.level,

--- a/renterd/renderer/contexts/config/types.ts
+++ b/renterd/renderer/contexts/config/types.ts
@@ -1,7 +1,6 @@
 export const defaultValues = {
   dataDir: '',
   mnemonic: '',
-  hasCopied: false,
   autoOpenWebUI: true,
   logLevel: 'info',
   httpAddress: 'localhost:9980',


### PR DESCRIPTION
- Copying the recovery phrase value is now only required if the value has changed.
- The recovery phrase is now displayed in a locked state if a saved value exists.
- Regenerating the recovery phrase now warns the user and asks for confirmation.
- Recovery phrase and password visibility selections no longer persist between app start, they now reset to hidden.

<img width="511" alt="Screenshot 2024-07-17 at 3 52 00 PM" src="https://github.com/user-attachments/assets/5bf8ae2a-bdee-49ed-8a83-4094a8abddae">
<img width="518" alt="Screenshot 2024-07-17 at 3 51 55 PM" src="https://github.com/user-attachments/assets/5430a97e-8f39-457c-875a-71968a8197bc">
<img width="511" alt="Screenshot 2024-07-17 at 3 52 06 PM" src="https://github.com/user-attachments/assets/bc65d57d-3e3a-4a0d-84ae-940f1b159407">