### PR TITLE
ci: add arch to macos dmg name

### DIFF
--- a/.changeset/tough-pumpkins-jump.md
+++ b/.changeset/tough-pumpkins-jump.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+The macOS releases now include both ARM64 and AMD64 dmgs, named with the following pattern: daemon-arch.dmg.

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,12 +10,13 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  mac-arm64:
+  mac:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
     strategy:
       fail-fast: false
       matrix:
         app: [hostd, renterd, walletd]
+        arch: [arm64, amd64]
     runs-on: macos-latest
     defaults:
       run:
@@ -65,23 +66,35 @@ jobs:
         run: npm run build
         shell: bash
       - name: Download daemon binary
-        run: npm run download:binary -- --goos=darwin --goarch=arm64
+        run: npm run download:binary -- --goos=darwin --goarch=${{ matrix.arch }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # Retry because macos notarization is often flakey and fails.
       - name: Package executable bundles, sign and notarize, make distributables
+        uses: nick-fields/retry@v3
         env:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
           APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH }}
-        run: npm run make -- --arch=arm64
-        shell: bash
-  linux-arm64:
+        with:
+          max_attempts: 3
+          timeout_minutes: 30
+          retry_wait_seconds: 5
+          command: |
+            cd ${{ matrix.app }}
+            APP_ARCH=${{ matrix.arch }}
+            if [ $APP_ARCH = "amd64" ]; then
+              APP_ARCH=x64
+            fi
+            npm run make -- --arch=$APP_ARCH
+  linux:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
     strategy:
       fail-fast: false
       matrix:
         app: [hostd, renterd, walletd]
+        arch: [arm64, amd64]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -100,43 +113,17 @@ jobs:
         run: npm run build
         shell: bash
       - name: Download daemon binary
-        run: npm run download:binary -- --goos=linux --goarch=arm64
+        run: npm run download:binary -- --goos=linux --goarch=${{ matrix.arch }}
         shell: bash
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Package executable bundles, make distributables
-        run: npm run make -- --arch=arm64
-        shell: bash
-  linux-amd64:
-    if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
-    strategy:
-      fail-fast: false
-      matrix:
-        app: [hostd, renterd, walletd]
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ matrix.app }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup
-        uses: ./.github/actions/daemon-setup
-        with:
-          daemon: ${{ matrix.app }}
-          node_version: 20.10.0
-      - name: Lint
-        run: npm run lint
-        shell: bash
-      - name: Build
-        run: npm run build
-        shell: bash
-      - name: Download daemon binary
-        run: npm run download:binary -- --goos=linux --goarch=amd64
-        shell: bash
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Package executable bundles, make distributables
-        run: npm run make -- --arch=x64
+        run: |
+          APP_ARCH=${{ matrix.arch }}
+          if [ $APP_ARCH = "amd64" ]; then
+            APP_ARCH=x64
+          fi
+          npm run make -- --arch=$APP_ARCH
         shell: bash
   windows-amd64:
     if: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         app: [hostd, renterd, walletd]
-        arch: [amd64, arm64]
+        arch: [arm64, amd64]
     runs-on: macos-latest
     defaults:
       run:

--- a/hostd/forge.config.js
+++ b/hostd/forge.config.js
@@ -58,11 +58,11 @@ module.exports = {
     {
       name: '@electron-forge/maker-dmg',
       platforms: ['darwin'],
-      config: {
-        name: 'hostd',
+      config:  (arch) => ({
+        name: `hostd-${arch}`,
         icon: './assets/icons/icon.icns',
         format: 'ULFO',
-      },
+      }),
     },
     {
       name: '@electron-forge/maker-deb',

--- a/renterd/forge.config.js
+++ b/renterd/forge.config.js
@@ -58,11 +58,11 @@ module.exports = {
     {
       name: '@electron-forge/maker-dmg',
       platforms: ['darwin'],
-      config: {
-        name: 'renterd',
+      config:  (arch) => ({
+        name: `renterd-${arch}`,
         icon: './assets/icons/icon.icns',
         format: 'ULFO',
-      },
+      }),
     },
     {
       name: '@electron-forge/maker-deb',

--- a/walletd/forge.config.js
+++ b/walletd/forge.config.js
@@ -58,11 +58,13 @@ module.exports = {
     {
       name: '@electron-forge/maker-dmg',
       platforms: ['darwin'],
-      config: {
-        name: 'walletd',
+      config:  (arch) => {
+        return ({
+        name: `walletd-${arch}`,
         icon: './assets/icons/icon.icns',
         format: 'ULFO',
-      },
+      })
+    },
     },
     {
       name: '@electron-forge/maker-deb',


### PR DESCRIPTION
- The macOS releases now include both ARM64 and AMD64 dmgs, named with the following pattern: daemon-arch.dmg.