### PR TITLE
fix: maker contructor arguments

### DIFF
--- a/.changeset/alpha-beta-charlie.md
+++ b/.changeset/alpha-beta-charlie.md
@@ -1,0 +1,7 @@
+---
+'hostd': patch
+'renterd': patch
+'walletd': patch
+---
+
+Fixed an issue with the publishing workflow that meant some app configuration was not being applied.

--- a/hostd/forge.config.js
+++ b/hostd/forge.config.js
@@ -9,9 +9,8 @@ const { execFileSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
 
-const makerSquirrel = new MakerSquirrel({
-  platforms: ['win32'],
-  config: (arch) => ({
+const makerSquirrel = new MakerSquirrel(
+  (arch) => ({
     // There is currently an issue with deltas.
     // Issue: System.IO.FileNotFoundException: The base package release does not exist
     noDelta: true,
@@ -21,40 +20,41 @@ const makerSquirrel = new MakerSquirrel({
     // The ICO file to use as the icon for the generated Setup.exe
     setupIcon: './assets/icons/icon.ico',
   }),
-})
-const makerZIP = new MakerZIP({
-  platforms: ['darwin'],
-  config: (arch) => ({
+  ['win32']
+)
+const makerZIP = new MakerZIP(
+  (arch) => ({
     macUpdateManifestBaseUrl: `https://releases.sia.tools/hostd/darwin/${arch}`,
     options: {
       icon: './assets/icons/icon.icns',
     },
   }),
-})
-const makerDMG = new MakerDMG({
-  platforms: ['darwin'],
-  config: (arch) => ({
+  ['darwin']
+)
+const makerDMG = new MakerDMG(
+  (arch) => ({
     name: `hostd-${arch}`,
     icon: './assets/icons/icon.icns',
     format: 'ULFO',
   }),
-})
-const makerDeb = new MakerDeb({
-  platforms: ['linux'],
-  config: {
+  ['darwin']
+)
+const makerDeb = new MakerDeb(
+  {
     options: {
       icon: './assets/icons/icon.png',
     },
   },
-})
-const makerRPM = new MakerRpm({
-  platforms: ['linux'],
-  config: {
+  ['linux']
+)
+const makerRPM = new MakerRpm(
+  {
     options: {
       icon: './assets/icons/icon.png',
     },
   },
-})
+  ['linux']
+)
 
 // THIS FIX IS TAKEN FROM: https://github.com/kando-menu/kando/pull/700/files
 // > Below comes an evil hack to fix this issue: https://github.com/kando-menu/kando/issues/502

--- a/hostd/package-lock.json
+++ b/hostd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hostd",
-  "version": "0.16.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hostd",
-      "version": "0.16.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "@electron-forge/maker-dmg": "^7.4.0",

--- a/renterd/forge.config.js
+++ b/renterd/forge.config.js
@@ -9,9 +9,8 @@ const { execFileSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
 
-const makerSquirrel = new MakerSquirrel({
-  platforms: ['win32'],
-  config: (arch) => ({
+const makerSquirrel = new MakerSquirrel(
+  (arch) => ({
     // There is currently an issue with deltas.
     // Issue: System.IO.FileNotFoundException: The base package release does not exist
     noDelta: true,
@@ -21,40 +20,41 @@ const makerSquirrel = new MakerSquirrel({
     // The ICO file to use as the icon for the generated Setup.exe
     setupIcon: './assets/icons/icon.ico',
   }),
-})
-const makerZIP = new MakerZIP({
-  platforms: ['darwin'],
-  config: (arch) => ({
+  ['win32']
+)
+const makerZIP = new MakerZIP(
+  (arch) => ({
     macUpdateManifestBaseUrl: `https://releases.sia.tools/renterd/darwin/${arch}`,
     options: {
       icon: './assets/icons/icon.icns',
     },
   }),
-})
-const makerDMG = new MakerDMG({
-  platforms: ['darwin'],
-  config: (arch) => ({
+  ['darwin']
+)
+const makerDMG = new MakerDMG(
+  (arch) => ({
     name: `renterd-${arch}`,
     icon: './assets/icons/icon.icns',
     format: 'ULFO',
   }),
-})
-const makerDeb = new MakerDeb({
-  platforms: ['linux'],
-  config: {
+  ['darwin']
+)
+const makerDeb = new MakerDeb(
+  {
     options: {
       icon: './assets/icons/icon.png',
     },
   },
-})
-const makerRPM = new MakerRpm({
-  platforms: ['linux'],
-  config: {
+  ['linux']
+)
+const makerRPM = new MakerRpm(
+  {
     options: {
       icon: './assets/icons/icon.png',
     },
   },
-})
+  ['linux']
+)
 
 // THIS FIX IS TAKEN FROM: https://github.com/kando-menu/kando/pull/700/files
 // > Below comes an evil hack to fix this issue: https://github.com/kando-menu/kando/issues/502

--- a/renterd/package-lock.json
+++ b/renterd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "renterd",
-  "version": "0.15.0",
+  "version": "0.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "renterd",
-      "version": "0.15.0",
+      "version": "0.17.1",
       "license": "MIT",
       "dependencies": {
         "@electron-forge/maker-dmg": "^7.4.0",

--- a/walletd/forge.config.js
+++ b/walletd/forge.config.js
@@ -9,9 +9,8 @@ const { execFileSync } = require('child_process')
 const fs = require('fs')
 const path = require('path')
 
-const makerSquirrel = new MakerSquirrel({
-  platforms: ['win32'],
-  config: (arch) => ({
+const makerSquirrel = new MakerSquirrel(
+  (arch) => ({
     // There is currently an issue with deltas.
     // Issue: System.IO.FileNotFoundException: The base package release does not exist
     noDelta: true,
@@ -21,40 +20,41 @@ const makerSquirrel = new MakerSquirrel({
     // The ICO file to use as the icon for the generated Setup.exe
     setupIcon: './assets/icons/icon.ico',
   }),
-})
-const makerZIP = new MakerZIP({
-  platforms: ['darwin'],
-  config: (arch) => ({
+  ['win32']
+)
+const makerZIP = new MakerZIP(
+  (arch) => ({
     macUpdateManifestBaseUrl: `https://releases.sia.tools/walletd/darwin/${arch}`,
     options: {
       icon: './assets/icons/icon.icns',
     },
   }),
-})
-const makerDMG = new MakerDMG({
-  platforms: ['darwin'],
-  config: (arch) => ({
+  ['darwin']
+)
+const makerDMG = new MakerDMG(
+  (arch) => ({
     name: `walletd-${arch}`,
     icon: './assets/icons/icon.icns',
     format: 'ULFO',
   }),
-})
-const makerDeb = new MakerDeb({
-  platforms: ['linux'],
-  config: {
+  ['darwin']
+)
+const makerDeb = new MakerDeb(
+  {
     options: {
       icon: './assets/icons/icon.png',
     },
   },
-})
-const makerRPM = new MakerRpm({
-  platforms: ['linux'],
-  config: {
+  ['linux']
+)
+const makerRPM = new MakerRpm(
+  {
     options: {
       icon: './assets/icons/icon.png',
     },
   },
-})
+  ['linux']
+)
 
 // THIS FIX IS TAKEN FROM: https://github.com/kando-menu/kando/pull/700/files
 // > Below comes an evil hack to fix this issue: https://github.com/kando-menu/kando/issues/502

--- a/walletd/package-lock.json
+++ b/walletd/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "walletd",
-  "version": "0.11.0",
+  "version": "0.12.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "walletd",
-      "version": "0.11.0",
+      "version": "0.12.1",
       "license": "MIT",
       "dependencies": {
         "@electron-forge/maker-dmg": "^7.4.0",


### PR DESCRIPTION
- Noticed the macos RELEASES.json was not being updated, the issue is that the maker constructor arguments look like: `MakerSquirrel(configOrConfigFetcher?, platformsToMakeOn?)` [docs](https://js.electronforge.io/classes/_electron_forge_maker_squirrel.MakerSquirrel.html#constructor) This PR fixes the issue so the config params are properly applied. 

Follow up to previous changes for https://github.com/SiaFoundation/desktop/issues/99