### PR TITLE
feat: logging improvements and hostd config fix

### DIFF
--- a/.changeset/eleven-llamas-refuse.md
+++ b/.changeset/eleven-llamas-refuse.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+The edge of the log viewer can be dragged to expand or shrink the viewer height.

--- a/.changeset/few-mirrors-teach.md
+++ b/.changeset/few-mirrors-teach.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+There is now a log viewer in the configuration window.

--- a/.changeset/funny-pianos-speak.md
+++ b/.changeset/funny-pianos-speak.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+The log viewer has actions for toggling the viewer, clearing the log, opening the actual log file.

--- a/.changeset/grumpy-paws-watch.md
+++ b/.changeset/grumpy-paws-watch.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+Errors generated in the UI are now also added to the logs in the log viewer for persistence and better visibility.

--- a/.changeset/plenty-tigers-reply.md
+++ b/.changeset/plenty-tigers-reply.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+Error toasts now use the full error message.

--- a/.changeset/quick-socks-protect.md
+++ b/.changeset/quick-socks-protect.md
@@ -1,0 +1,5 @@
+---
+'hostd': patch
+---
+
+Fixed config field name for syncer address.

--- a/hostd/main/config.ts
+++ b/hostd/main/config.ts
@@ -3,13 +3,14 @@ import * as path from 'path'
 import * as yaml from 'js-yaml'
 import { app } from 'electron'
 import { deepmerge } from '@fastify/deepmerge'
+import { MaybeError } from './types'
 
 export type Config = {
   name: string
   recoveryPhrase: string
   directory: string
-  consensus: {
-    gatewayAddress: string
+  syncer: {
+    address: string
   }
   autoOpenWebUI: boolean
   http: {
@@ -32,8 +33,8 @@ const defaultConfig: Config = {
   recoveryPhrase: '',
   directory: getDefaultDataPath(),
   autoOpenWebUI: true,
-  consensus: {
-    gatewayAddress: ':9981',
+  syncer: {
+    address: ':9981',
   },
   log: {
     level: 'info',
@@ -65,25 +66,40 @@ export function getIsConfigured(): boolean {
 }
 
 // Save the configuration
-export async function saveConfig(config: Config): Promise<void> {
+export async function saveConfig(config: Config): Promise<MaybeError> {
+  if (config.recoveryPhrase === '') {
+    return {
+      error: new Error('Recovery phrase must be set'),
+    }
+  }
   if (config.http.password === '') {
-    throw new Error('password must be set')
+    return {
+      error: new Error('password must be set'),
+    }
   }
 
   if (!config.directory) {
     config.directory = getDefaultDataPath()
   }
 
-  await fs.promises.mkdir(config.directory, { recursive: true })
-  await fs.promises.mkdir(getConfigDirectoryPath(), {
-    recursive: true,
-  })
+  try {
+    await fs.promises.mkdir(config.directory, { recursive: true })
+    await fs.promises.mkdir(getConfigDirectoryPath(), {
+      recursive: true,
+    })
 
-  const existingConfig = getConfig()
-  const merge = deepmerge({ all: true })
-  const mergedConfig = merge(defaultConfig, existingConfig, config)
+    const existingConfig = getConfig()
+    const merge = deepmerge({ all: true })
+    const mergedConfig = merge(defaultConfig, existingConfig, config)
 
-  await fs.promises.writeFile(getConfigFilePath(), yaml.dump(mergedConfig))
+    await fs.promises.writeFile(getConfigFilePath(), yaml.dump(mergedConfig))
+  } catch (e) {
+    return {
+      error: e as Error,
+    }
+  }
+
+  return {}
 }
 
 // Get the configuration

--- a/hostd/main/daemon.ts
+++ b/hostd/main/daemon.ts
@@ -1,18 +1,22 @@
 import { spawn } from 'child_process'
-import { state } from './state'
+import { state, addDaemonLog } from './state'
 import { getConfig, getConfigFilePath } from './config'
 import { getBinaryFilePath, getDaemonDirectoryPath } from './binary'
 import path from 'path'
 import fs from 'fs'
 import { MaybeError } from './types'
+import { parseLogLine } from './logs'
 
 const configFileVariableName = 'HOSTD_CONFIG_FILE'
 
 export async function startDaemon(): Promise<MaybeError> {
   try {
     await stopDaemon()
+    state.daemonLogs = []
     const config = getConfig()
     const binaryFilePath = getBinaryFilePath()
+
+    console.log('Starting hostd daemon...')
     state.daemon = spawn(binaryFilePath, [], {
       env: { ...process.env, [configFileVariableName]: getConfigFilePath() },
       cwd: config.directory,
@@ -21,22 +25,45 @@ export async function startDaemon(): Promise<MaybeError> {
     let startupError: Error | null = null
 
     state.daemon.stdout?.on('data', (data) => {
-      console.log(`stdout: ${data}`)
+      const message = data.toString()
+      const lines = message.split(/\r?\n/).filter(Boolean)
+      lines.forEach((line: string) => {
+        console.log(`[hostd] ${line}`)
+        const parsed = parseLogLine(line)
+        if (parsed) {
+          addDaemonLog(parsed)
+        }
+      })
     })
 
     state.daemon.stderr?.on('data', (data) => {
-      console.error(`stderr: ${data}`)
-      startupError = new Error(data)
+      const message = data.toString()
+      const lines = message.split(/\r?\n/).filter(Boolean)
+      lines.forEach((line: string) => {
+        console.error(`[hostd] ${line}`)
+        const parsed = parseLogLine(line)
+        if (parsed) {
+          addDaemonLog(parsed)
+        }
+      })
+      startupError = new Error(message)
     })
 
     state.daemon.on('error', (error) => {
-      console.log(`child process exited with error ${error}`)
+      console.error('Daemon process error:', error)
       state.daemon = null
+      addDaemonLog({
+        timestamp: new Date(),
+        level: 'ERROR',
+        source: 'daemon',
+        message: error.toString(),
+        raw: error.toString(),
+      })
       startupError = error
     })
 
-    state.daemon.on('close', (code) => {
-      console.log(`child process exited with code ${code}`)
+    state.daemon.on('close', () => {
+      console.log('Daemon process closed')
       state.daemon = null
     })
 
@@ -44,16 +71,27 @@ export async function startDaemon(): Promise<MaybeError> {
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
     if (startupError) {
+      console.error('Daemon startup error:', startupError)
       return {
         error: startupError,
       }
     }
 
+    console.log('Daemon started successfully')
     return {}
   } catch (err) {
+    const error = err as Error
+    console.error('Failed to start daemon:', error)
+    addDaemonLog({
+      timestamp: new Date(),
+      level: 'ERROR',
+      source: 'daemon',
+      message: error.toString(),
+      raw: error.toString(),
+    })
     state.daemon = null
     return {
-      error: err as Error,
+      error,
     }
   }
 }

--- a/hostd/main/ipc.ts
+++ b/hostd/main/ipc.ts
@@ -14,6 +14,8 @@ import {
   saveConfig,
 } from './config'
 import { closeMainWindow } from './window'
+import { state } from './state'
+import path from 'path'
 
 export function initIpc() {
   ipcMain.handle('open-browser', (_, url: string) => {
@@ -39,7 +41,8 @@ export function initIpc() {
     return getIsConfigured()
   })
   ipcMain.handle('open-data-directory', () => {
-    shell.openPath(getDefaultDataPath())
+    const config = getConfig()
+    shell.openPath(config.directory)
     return true
   })
   ipcMain.handle('get-default-data-directory', async () => {
@@ -52,5 +55,20 @@ export function initIpc() {
   ipcMain.handle('config-save', async (_, config: Config) => {
     await saveConfig(config)
     return true
+  })
+  ipcMain.handle('get-daemon-logs', () => {
+    return state.daemonLogs
+  })
+  ipcMain.handle('clear-daemon-logs', () => {
+    state.daemonLogs = []
+    return true
+  })
+  ipcMain.handle('open-log-file', () => {
+    const config = getConfig()
+    const logPath = path.join(config.directory, 'hostd.log')
+    if (fs.existsSync(logPath)) {
+      return shell.openPath(logPath)
+    }
+    return false
   })
 }

--- a/hostd/main/logs.ts
+++ b/hostd/main/logs.ts
@@ -1,0 +1,50 @@
+export type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
+
+export interface DaemonLog {
+  timestamp: Date
+  level: LogLevel
+  source: string
+  message: string
+  raw: string
+}
+
+function stripAnsiCodes(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[\d+m/g, '')
+}
+
+export function parseLogLine(line: string): DaemonLog | null {
+  try {
+    // Strip ANSI color codes
+    const cleanLine = stripAnsiCodes(line)
+    // Try to parse as structured log first
+    const parts = cleanLine.split(/\s+/)
+    // Check if it's a structured log (has timestamp and level)
+    if (parts[0]?.match(/^\d{4}-\d{2}-\d{2}T/)) {
+      if (parts.length < 4) return null
+      const timestamp = parts[0]
+      const level = parts[1] as LogLevel
+      const source = parts[2]
+      const message = parts.slice(3).join(' ')
+      if (!['INFO', 'ERROR', 'WARN', 'DEBUG'].includes(level)) return null
+      return {
+        timestamp: new Date(timestamp),
+        level,
+        source: source.replace(/:$/, ''),
+        message,
+        raw: cleanLine,
+      }
+    }
+    // Handle error messages
+    return {
+      timestamp: new Date(),
+      level: 'ERROR',
+      source: 'daemon',
+      message: cleanLine,
+      raw: cleanLine,
+    }
+  } catch (e) {
+    console.error('Failed to parse log line:', e)
+    return null
+  }
+}

--- a/hostd/main/preload.ts
+++ b/hostd/main/preload.ts
@@ -17,4 +17,7 @@ contextBridge.exposeInMainWorld('electron', {
   getDefaultDataDirectory: () =>
     ipcRenderer.invoke('get-default-data-directory'),
   getInstalledVersion: () => ipcRenderer.invoke('get-installed-version'),
+  getDaemonLogs: () => ipcRenderer.invoke('get-daemon-logs'),
+  clearDaemonLogs: () => ipcRenderer.invoke('clear-daemon-logs'),
+  openLogFile: () => ipcRenderer.invoke('open-log-file'),
 })

--- a/hostd/main/startup.ts
+++ b/hostd/main/startup.ts
@@ -3,11 +3,14 @@ import { getIsConfigured } from './config'
 import { state } from './state'
 import { env } from './env'
 
-export function startup() {
+export async function startup() {
   // If the app is already configured, start the daemon and open browser
   // and do not show the configuration window.
   if (getIsConfigured()) {
-    startDaemon()
+    const { error } = await startDaemon()
+    if (error) {
+      return
+    }
     state.mainWindow?.close()
   }
 

--- a/hostd/main/state.ts
+++ b/hostd/main/state.ts
@@ -1,14 +1,25 @@
 import { ChildProcess } from 'child_process'
 import { BrowserWindow, Tray } from 'electron'
+import { DaemonLog } from './logs'
 
 export const state: {
   mainWindow: BrowserWindow | null
   tray: Tray | null
   daemon: ChildProcess | null
   isQuitting: boolean
+  daemonLogs: DaemonLog[]
 } = {
   mainWindow: null,
   tray: null,
   isQuitting: false,
   daemon: null,
+  daemonLogs: [],
+}
+
+export function addDaemonLog(log: DaemonLog) {
+  // Ensure there are never more than 1000 logs.
+  if (state.daemonLogs.length > 1000) {
+    state.daemonLogs.shift()
+  }
+  state.daemonLogs.push(log)
 }

--- a/hostd/renderer/components/App.tsx
+++ b/hostd/renderer/components/App.tsx
@@ -4,6 +4,7 @@ import { AppBackdrop, ScrollArea } from '@siafoundation/design-system'
 import { ConfigForm } from './ConfigForm'
 import { useConfig } from '../contexts/config'
 import { Header } from './Header'
+import { LogViewer } from './LogViewer'
 
 export function App() {
   const { onSubmit } = useConfig()
@@ -11,13 +12,14 @@ export function App() {
     <form onSubmit={onSubmit}>
       <AppBackdrop />
       <div className="flex flex-col w-full h-screen justify-center items-center">
-        <ScrollArea className="flex-1">
-          <div className="flex flex-col gap-3 w-full justify-center items-center pb-4">
+        <ScrollArea className="flex-1 [&>div>div]:!block">
+          <div className="flex flex-col gap-3 w-full justify-center items-center pb-14">
             <Header />
             <ConfigForm />
           </div>
         </ScrollArea>
       </div>
+      <LogViewer />
     </form>
   )
 }

--- a/hostd/renderer/components/ConfigForm.tsx
+++ b/hostd/renderer/components/ConfigForm.tsx
@@ -68,11 +68,7 @@ export function ConfigForm() {
                 <FieldText form={form} fields={fields} name="httpAddress" />
               </div>
               <div className="flex-1">
-                <FieldText
-                  form={form}
-                  fields={fields}
-                  name="consensusGatewayAddress"
-                />
+                <FieldText form={form} fields={fields} name="syncerAddress" />
               </div>
             </div>
             <div className="flex gap-2">

--- a/hostd/renderer/components/LogViewer.tsx
+++ b/hostd/renderer/components/LogViewer.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  Panel,
+  Button,
+  ScrollArea,
+  copyToClipboard,
+  Text,
+} from '@siafoundation/design-system'
+import {
+  Reset16,
+  ChevronUp16,
+  ChevronDown16,
+  Launch16,
+} from '@siafoundation/react-icons'
+import useSWR from 'swr'
+import { LogLevel } from '../../main/logs'
+import { cx } from 'class-variance-authority'
+
+const defaultHeight = 400
+const storageKey = 'logViewerHeight'
+
+const levelColors: Record<LogLevel, string> = {
+  INFO: 'text-green-500',
+  ERROR: 'text-red-500',
+  WARN: 'text-amber-500',
+  DEBUG: 'text-blue-500',
+}
+
+export function LogViewer() {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [height, setHeight] = useState(() => {
+    if (typeof window === 'undefined') return defaultHeight
+    const saved = window.localStorage.getItem(storageKey)
+    return saved ? parseInt(saved, 10) : defaultHeight
+  })
+  const [dragOffset, setDragOffset] = useState(0)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<HTMLDivElement>(null)
+  const isDraggingRef = useRef(false)
+  const startYRef = useRef(0)
+  const startHeightRef = useRef(0)
+
+  const { data: logs = [], mutate } = useSWR(
+    'daemon-logs',
+    () => window.electron.getDaemonLogs(),
+    {
+      refreshInterval: 1000,
+    }
+  )
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [logs])
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current) return
+      const dy = startYRef.current - e.clientY
+      setDragOffset(dy)
+    }
+
+    const handleMouseUp = () => {
+      if (!isDraggingRef.current) return
+      isDraggingRef.current = false
+      document.body.style.cursor = 'default'
+
+      const newHeight = Math.min(
+        Math.max(200, startHeightRef.current + dragOffset),
+        window.innerHeight * 0.9
+      )
+      setHeight(newHeight)
+      window.localStorage.setItem(storageKey, String(newHeight))
+      setDragOffset(0)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [dragOffset])
+
+  const startDragging = (e: React.MouseEvent) => {
+    e.preventDefault()
+    isDraggingRef.current = true
+    startYRef.current = e.clientY
+    startHeightRef.current = height
+    document.body.style.cursor = 'row-resize'
+  }
+
+  const clearLogs = async () => {
+    await window.electron.clearDaemonLogs()
+    mutate()
+  }
+
+  const openLogFile = async () => {
+    await window.electron.openLogFile()
+  }
+
+  const currentHeight = isExpanded ? height + dragOffset : 40
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50"
+      style={{
+        height: currentHeight,
+        transition: isDraggingRef.current ? 'none' : 'height 0.3s ease',
+      }}
+    >
+      {isExpanded && (
+        <div
+          ref={dragRef}
+          className="absolute top-0 left-0 right-0 h-1 cursor-row-resize bg-gray-800 hover:bg-accent-500 transition-colors"
+          onMouseDown={startDragging}
+        />
+      )}
+      <Panel className="h-full flex flex-col rounded-b-none">
+        <div
+          className={`flex items-center gap-2 px-2 ${
+            isExpanded ? 'py-2' : 'py-1.5'
+          } select-none`}
+        >
+          <div className="text-sm font-medium">Logs</div>
+          <div className="flex-1" />
+          {isExpanded && (
+            <>
+              <Button
+                variant="gray"
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  clearLogs()
+                }}
+              >
+                <Reset16 />
+                clear view
+              </Button>
+              <Button
+                variant="gray"
+                size="small"
+                className="text-xs gap-1"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  openLogFile()
+                }}
+              >
+                <Launch16 />
+                open file
+              </Button>
+            </>
+          )}
+          <div className="w-px h-3 bg-gray-800/50" />
+          <Button
+            variant="gray"
+            size="small"
+            onClick={() => setIsExpanded(!isExpanded)}
+            aria-label={isExpanded ? 'Collapse logs' : 'Expand logs'}
+          >
+            {isExpanded ? <ChevronDown16 /> : <ChevronUp16 />}
+          </Button>
+        </div>
+
+        {isExpanded ? (
+          logs.length > 0 ? (
+            <ScrollArea ref={scrollRef} className="flex-1">
+              <table className="w-full border-collapse font-mono text-xs relative">
+                <thead>
+                  <tr
+                    className={cx('z-10 text-xs sticky top-0', [
+                      'bg-white dark:bg-graydark-200',
+                      'shadow-border-b shadow-gray-400 dark:shadow-graydark-400',
+                    ])}
+                  >
+                    <th className="px-2 py-1.5 text-left font-medium">Time</th>
+                    <th className="px-2 py-1.5 text-left font-medium">Level</th>
+                    <th className="px-2 py-1.5 text-left font-medium">
+                      Source
+                    </th>
+                    <th className="px-2 py-1.5 text-left font-medium">
+                      Message
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {logs.map((log, i) => (
+                    <tr
+                      key={i}
+                      className={cx(
+                        'hover:bg-gray-200 dark:hover:bg-graydark-400',
+                        'transition-colors'
+                      )}
+                      onClick={() => copyToClipboard(log.raw, 'log')}
+                    >
+                      <td className="px-2 py-1 whitespace-nowrap opacity-50">
+                        {log.timestamp.toLocaleTimeString()}
+                      </td>
+                      <td
+                        className={`px-2 py-1 whitespace-nowrap font-semibold ${
+                          levelColors[log.level]
+                        }`}
+                      >
+                        {log.level}
+                      </td>
+                      <td className="px-2 py-1 whitespace-nowrap opacity-75">
+                        {log.source}
+                      </td>
+                      <td className="px-2 py-1">
+                        <div className="whitespace-pre">{log.message}</div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ScrollArea>
+          ) : (
+            <div className="flex flex-col h-full items-center justify-center">
+              <Text size="16" color="verySubtle">
+                No logs
+              </Text>
+            </div>
+          )
+        ) : null}
+      </Panel>
+    </div>
+  )
+}

--- a/hostd/renderer/components/useConfigData.tsx
+++ b/hostd/renderer/components/useConfigData.tsx
@@ -7,8 +7,8 @@ export type Config = {
   recoveryPhrase: string
   directory: string
   autoOpenWebUI: boolean
-  consensus: {
-    gatewayAddress: string
+  syncer: {
+    address: string
   }
   http: {
     address: string

--- a/hostd/renderer/components/useDaemon.tsx
+++ b/hostd/renderer/components/useDaemon.tsx
@@ -22,7 +22,7 @@ export function useDaemon() {
     if (error) {
       console.error(error)
       triggerErrorToast({
-        title: `Error starting daemon`,
+        title: error.message,
       })
     }
     await isRunning.mutate()
@@ -34,7 +34,7 @@ export function useDaemon() {
     if (error) {
       console.error(error)
       triggerErrorToast({
-        title: `Error stopping daemon`,
+        title: error.message,
       })
     }
     await isRunning.mutate()

--- a/hostd/renderer/contexts/config/fields.tsx
+++ b/hostd/renderer/contexts/config/fields.tsx
@@ -119,9 +119,9 @@ export function getFields({
         required: 'required',
       },
     },
-    consensusGatewayAddress: {
+    syncerAddress: {
       type: 'text',
-      title: 'Gateway address',
+      title: 'Syncer address',
       placeholder: ':9981',
       validation: {},
     },

--- a/hostd/renderer/contexts/config/index.tsx
+++ b/hostd/renderer/contexts/config/index.tsx
@@ -1,13 +1,6 @@
 'use client'
 
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react'
+import { createContext, useCallback, useContext, useMemo } from 'react'
 import {
   triggerErrorToast,
   useFormInit,
@@ -116,7 +109,7 @@ function useConfigMain() {
       if (saveConfig.error) {
         console.error(saveConfig.error)
         triggerErrorToast({
-          title: 'Error saving settings',
+          title: saveConfig.error.message,
         })
         return
       }

--- a/hostd/renderer/contexts/config/transform.ts
+++ b/hostd/renderer/contexts/config/transform.ts
@@ -17,7 +17,7 @@ export function transformDown({
     autoOpenWebUI: config.autoOpenWebUI,
     httpAddress: config.http.address,
     httpPassword: config.http.password,
-    consensusGatewayAddress: config.consensus.gatewayAddress,
+    syncerAddress: config.syncer.address,
     rhp2Address: config.rhp2.address,
     rhp3AddressTcp: config.rhp3.tcp,
     logLevel: config.log.level,
@@ -34,8 +34,8 @@ export function transformUp(data: ConfigValues): Config {
       address: data.httpAddress,
       password: data.httpPassword,
     },
-    consensus: {
-      gatewayAddress: data.consensusGatewayAddress,
+    syncer: {
+      address: data.syncerAddress,
     },
     rhp2: { address: data.rhp2Address },
     rhp3: {

--- a/hostd/renderer/contexts/config/types.ts
+++ b/hostd/renderer/contexts/config/types.ts
@@ -5,7 +5,7 @@ export const defaultValues = {
   autoOpenWebUI: true,
   httpAddress: 'localhost:9980',
   httpPassword: '',
-  consensusGatewayAddress: ':9981',
+  syncerAddress: ':9981',
   rhp2Address: ':9982',
   rhp3AddressTcp: ':9983',
   logLevel: 'info',

--- a/hostd/renderer/next-env.d.ts
+++ b/hostd/renderer/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/hostd/renderer/renderer.d.ts
+++ b/hostd/renderer/renderer.d.ts
@@ -1,6 +1,14 @@
 import { Config } from './components/useConfigData'
 
 type MaybeError = { error?: Error }
+type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
+type DaemonLog = {
+  timestamp: Date
+  level: LogLevel
+  source: string
+  message: string
+  raw: string
+}
 
 export interface API {
   closeWindow: () => Promise<void>
@@ -14,6 +22,9 @@ export interface API {
   getDefaultDataDirectory: () => Promise<string>
   getInstalledVersion: () => Promise<string>
   saveConfig: (config: Config) => Promise<MaybeError>
+  getDaemonLogs: () => Promise<DaemonLog[]>
+  clearDaemonLogs: () => Promise<boolean>
+  openLogFile: () => Promise<boolean>
 }
 
 declare global {

--- a/renterd/main/config.ts
+++ b/renterd/main/config.ts
@@ -70,16 +70,22 @@ export async function saveConfig(config: Config): Promise<MaybeError> {
     config.directory = getDefaultDataPath()
   }
 
-  await fs.promises.mkdir(config.directory, { recursive: true })
-  await fs.promises.mkdir(getConfigDirectoryPath(), {
-    recursive: true,
-  })
+  try {
+    await fs.promises.mkdir(config.directory, { recursive: true })
+    await fs.promises.mkdir(getConfigDirectoryPath(), {
+      recursive: true,
+    })
 
-  const existingConfig = getConfig()
-  const merge = deepmerge({ all: true })
-  const mergedConfig = merge(defaultConfig, existingConfig, config)
+    const existingConfig = getConfig()
+    const merge = deepmerge({ all: true })
+    const mergedConfig = merge(defaultConfig, existingConfig, config)
 
-  await fs.promises.writeFile(getConfigFilePath(), yaml.dump(mergedConfig))
+    await fs.promises.writeFile(getConfigFilePath(), yaml.dump(mergedConfig))
+  } catch (e) {
+    return {
+      error: e as Error,
+    }
+  }
 
   return {}
 }

--- a/renterd/main/daemon.ts
+++ b/renterd/main/daemon.ts
@@ -1,18 +1,22 @@
 import { spawn } from 'child_process'
-import { state } from './state'
+import { state, addDaemonLog } from './state'
 import { getConfig, getConfigFilePath } from './config'
 import { getBinaryFilePath, getDaemonDirectoryPath } from './binary'
 import path from 'path'
 import fs from 'fs'
 import { MaybeError } from './types'
+import { parseLogLine } from './logs'
 
 const configFileVariableName = 'RENTERD_CONFIG_FILE'
 
 export async function startDaemon(): Promise<MaybeError> {
   try {
     await stopDaemon()
+    state.daemonLogs = []
     const config = getConfig()
     const binaryFilePath = getBinaryFilePath()
+
+    console.log('Starting renterd daemon...')
     state.daemon = spawn(binaryFilePath, [], {
       env: { ...process.env, [configFileVariableName]: getConfigFilePath() },
       cwd: config.directory,
@@ -21,22 +25,45 @@ export async function startDaemon(): Promise<MaybeError> {
     let startupError: Error | null = null
 
     state.daemon.stdout?.on('data', (data) => {
-      console.log(`stdout: ${data}`)
+      const message = data.toString()
+      const lines = message.split(/\r?\n/).filter(Boolean)
+      lines.forEach((line: string) => {
+        console.log(`[renterd] ${line}`)
+        const parsed = parseLogLine(line)
+        if (parsed) {
+          addDaemonLog(parsed)
+        }
+      })
     })
 
     state.daemon.stderr?.on('data', (data) => {
-      console.error(`stderr: ${data}`)
-      startupError = new Error(data)
+      const message = data.toString()
+      const lines = message.split(/\r?\n/).filter(Boolean)
+      lines.forEach((line: string) => {
+        console.error(`[renterd] ${line}`)
+        const parsed = parseLogLine(line)
+        if (parsed) {
+          addDaemonLog(parsed)
+        }
+      })
+      startupError = new Error(message)
     })
 
     state.daemon.on('error', (error) => {
-      console.log(`child process exited with error ${error}`)
+      console.error('Daemon process error:', error)
       state.daemon = null
+      addDaemonLog({
+        timestamp: new Date(),
+        level: 'ERROR',
+        source: 'daemon',
+        message: error.toString(),
+        raw: error.toString(),
+      })
       startupError = error
     })
 
-    state.daemon.on('close', (code) => {
-      console.log(`child process exited with code ${code}`)
+    state.daemon.on('close', () => {
+      console.log('Daemon process closed')
       state.daemon = null
     })
 
@@ -44,16 +71,27 @@ export async function startDaemon(): Promise<MaybeError> {
     await new Promise((resolve) => setTimeout(resolve, 3000))
 
     if (startupError) {
+      console.error('Daemon startup error:', startupError)
       return {
         error: startupError,
       }
     }
 
+    console.log('Daemon started successfully')
     return {}
   } catch (err) {
+    const error = err as Error
+    console.error('Failed to start daemon:', error)
+    addDaemonLog({
+      timestamp: new Date(),
+      level: 'ERROR',
+      source: 'daemon',
+      message: error.toString(),
+      raw: error.toString(),
+    })
     state.daemon = null
     return {
-      error: err as Error,
+      error,
     }
   }
 }

--- a/renterd/main/ipc.ts
+++ b/renterd/main/ipc.ts
@@ -14,6 +14,8 @@ import {
   saveConfig,
 } from './config'
 import { closeMainWindow } from './window'
+import { state } from './state'
+import path from 'path'
 
 export function initIpc() {
   ipcMain.handle('open-browser', (_, url: string) => {
@@ -39,7 +41,8 @@ export function initIpc() {
     return getIsConfigured()
   })
   ipcMain.handle('open-data-directory', () => {
-    shell.openPath(getDefaultDataPath())
+    const config = getConfig()
+    shell.openPath(config.directory)
     return true
   })
   ipcMain.handle('get-default-data-directory', async () => {
@@ -51,5 +54,20 @@ export function initIpc() {
   })
   ipcMain.handle('config-save', async (_, config: Config) => {
     return saveConfig(config)
+  })
+  ipcMain.handle('get-daemon-logs', () => {
+    return state.daemonLogs
+  })
+  ipcMain.handle('clear-daemon-logs', () => {
+    state.daemonLogs = []
+    return true
+  })
+  ipcMain.handle('open-log-file', () => {
+    const config = getConfig()
+    const logPath = path.join(config.directory, 'renterd.log')
+    if (fs.existsSync(logPath)) {
+      return shell.openPath(logPath)
+    }
+    return false
   })
 }

--- a/renterd/main/logs.ts
+++ b/renterd/main/logs.ts
@@ -1,0 +1,56 @@
+export type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
+
+export interface DaemonLog {
+  timestamp: Date
+  level: LogLevel
+  source: string
+  message: string
+  raw: string
+}
+
+function stripAnsiCodes(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[\d+m/g, '')
+}
+
+export function parseLogLine(line: string): DaemonLog | null {
+  try {
+    // Strip ANSI color codes
+    const cleanLine = stripAnsiCodes(line)
+
+    // Try to parse as structured log first
+    const parts = cleanLine.split(/\s+/)
+
+    // Check if it's a structured log (has timestamp and level)
+    if (parts[0]?.match(/^\d{4}-\d{2}-\d{2}T/)) {
+      if (parts.length < 4) return null
+
+      const timestamp = parts[0]
+      const level = parts[1] as LogLevel
+      const source = parts[2]
+      const message = parts.slice(3).join(' ')
+
+      if (!['INFO', 'ERROR', 'WARN', 'DEBUG'].includes(level)) return null
+
+      return {
+        timestamp: new Date(timestamp),
+        level,
+        source: source.replace(/:$/, ''),
+        message,
+        raw: cleanLine,
+      }
+    }
+
+    // Handle error messages
+    return {
+      timestamp: new Date(),
+      level: 'ERROR',
+      source: 'daemon',
+      message: cleanLine,
+      raw: cleanLine,
+    }
+  } catch (e) {
+    console.error('Failed to parse log line:', e)
+    return null
+  }
+}

--- a/renterd/main/preload.ts
+++ b/renterd/main/preload.ts
@@ -17,4 +17,7 @@ contextBridge.exposeInMainWorld('electron', {
   getDefaultDataDirectory: () =>
     ipcRenderer.invoke('get-default-data-directory'),
   getInstalledVersion: () => ipcRenderer.invoke('get-installed-version'),
+  getDaemonLogs: () => ipcRenderer.invoke('get-daemon-logs'),
+  clearDaemonLogs: () => ipcRenderer.invoke('clear-daemon-logs'),
+  openLogFile: () => ipcRenderer.invoke('open-log-file'),
 })

--- a/renterd/main/startup.ts
+++ b/renterd/main/startup.ts
@@ -4,11 +4,14 @@ import { getConfig, getIsConfigured } from './config'
 import { state } from './state'
 import { env } from './env'
 
-export function startup() {
+export async function startup() {
   // If the app is already configured, start the daemon and open browser
   // and do not show the configuration window.
   if (getIsConfigured()) {
-    startDaemon()
+    const { error } = await startDaemon()
+    if (error) {
+      return
+    }
     state.mainWindow?.close()
     shell.openExternal(`http://${getConfig().http.address}`)
   }

--- a/renterd/main/state.ts
+++ b/renterd/main/state.ts
@@ -1,14 +1,25 @@
 import { ChildProcess } from 'child_process'
 import { BrowserWindow, Tray } from 'electron'
+import { DaemonLog } from './logs'
 
 export const state: {
   mainWindow: BrowserWindow | null
   tray: Tray | null
   daemon: ChildProcess | null
   isQuitting: boolean
+  daemonLogs: DaemonLog[]
 } = {
   mainWindow: null,
   tray: null,
   isQuitting: false,
   daemon: null,
+  daemonLogs: [],
+}
+
+export function addDaemonLog(log: DaemonLog) {
+  // Ensure there are never more than 1000 logs.
+  if (state.daemonLogs.length > 1000) {
+    state.daemonLogs.shift()
+  }
+  state.daemonLogs.push(log)
 }

--- a/renterd/renderer/components/App.tsx
+++ b/renterd/renderer/components/App.tsx
@@ -4,6 +4,7 @@ import { AppBackdrop, ScrollArea } from '@siafoundation/design-system'
 import { ConfigForm } from './ConfigForm'
 import { useConfig } from '../contexts/config'
 import { Header } from './Header'
+import { LogViewer } from './LogViewer'
 
 export function App() {
   const { onSubmit } = useConfig()
@@ -11,13 +12,14 @@ export function App() {
     <form onSubmit={onSubmit}>
       <AppBackdrop />
       <div className="flex flex-col w-full h-screen justify-center items-center">
-        <ScrollArea className="flex-1">
-          <div className="flex flex-col gap-3 w-full justify-center items-center pb-4">
+        <ScrollArea className="flex-1 [&>div>div]:!block">
+          <div className="flex flex-col gap-3 w-full justify-center items-center pb-14">
             <Header />
             <ConfigForm />
           </div>
         </ScrollArea>
       </div>
+      <LogViewer />
     </form>
   )
 }

--- a/renterd/renderer/components/LogViewer.tsx
+++ b/renterd/renderer/components/LogViewer.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  Panel,
+  Button,
+  ScrollArea,
+  copyToClipboard,
+  Text,
+} from '@siafoundation/design-system'
+import {
+  Reset16,
+  ChevronUp16,
+  ChevronDown16,
+  Launch16,
+} from '@siafoundation/react-icons'
+import useSWR from 'swr'
+import { LogLevel } from '../../main/logs'
+import { cx } from 'class-variance-authority'
+
+const defaultHeight = 400
+const storageKey = 'logViewerHeight'
+
+const levelColors: Record<LogLevel, string> = {
+  INFO: 'text-green-500',
+  ERROR: 'text-red-500',
+  WARN: 'text-amber-500',
+  DEBUG: 'text-blue-500',
+}
+
+export function LogViewer() {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [height, setHeight] = useState(() => {
+    if (typeof window === 'undefined') return defaultHeight
+    const saved = window.localStorage.getItem(storageKey)
+    return saved ? parseInt(saved, 10) : defaultHeight
+  })
+  const [dragOffset, setDragOffset] = useState(0)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<HTMLDivElement>(null)
+  const isDraggingRef = useRef(false)
+  const startYRef = useRef(0)
+  const startHeightRef = useRef(0)
+
+  const { data: logs = [], mutate } = useSWR(
+    'daemon-logs',
+    () => window.electron.getDaemonLogs(),
+    {
+      refreshInterval: 1000,
+    }
+  )
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [logs])
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current) return
+      const dy = startYRef.current - e.clientY
+      setDragOffset(dy)
+    }
+
+    const handleMouseUp = () => {
+      if (!isDraggingRef.current) return
+      isDraggingRef.current = false
+      document.body.style.cursor = 'default'
+
+      const newHeight = Math.min(
+        Math.max(200, startHeightRef.current + dragOffset),
+        window.innerHeight * 0.9
+      )
+      setHeight(newHeight)
+      window.localStorage.setItem(storageKey, String(newHeight))
+      setDragOffset(0)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [dragOffset])
+
+  const startDragging = (e: React.MouseEvent) => {
+    e.preventDefault()
+    isDraggingRef.current = true
+    startYRef.current = e.clientY
+    startHeightRef.current = height
+    document.body.style.cursor = 'row-resize'
+  }
+
+  const clearLogs = async () => {
+    await window.electron.clearDaemonLogs()
+    mutate()
+  }
+
+  const openLogFile = async () => {
+    await window.electron.openLogFile()
+  }
+
+  const currentHeight = isExpanded ? height + dragOffset : 40
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50"
+      style={{
+        height: currentHeight,
+        transition: isDraggingRef.current ? 'none' : 'height 0.3s ease',
+      }}
+    >
+      {isExpanded && (
+        <div
+          ref={dragRef}
+          className="absolute top-0 left-0 right-0 h-1 cursor-row-resize bg-gray-800 hover:bg-accent-500 transition-colors"
+          onMouseDown={startDragging}
+        />
+      )}
+      <Panel className="h-full flex flex-col rounded-b-none">
+        <div
+          className={`flex items-center gap-2 px-2 ${
+            isExpanded ? 'py-2' : 'py-1.5'
+          } select-none`}
+        >
+          <div className="text-sm font-medium">Logs</div>
+          <div className="flex-1" />
+          {isExpanded && (
+            <>
+              <Button
+                variant="gray"
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  clearLogs()
+                }}
+              >
+                <Reset16 />
+                clear view
+              </Button>
+              <Button
+                variant="gray"
+                size="small"
+                className="text-xs gap-1"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  openLogFile()
+                }}
+              >
+                <Launch16 />
+                open file
+              </Button>
+            </>
+          )}
+          <div className="w-px h-3 bg-gray-800/50" />
+          <Button
+            variant="gray"
+            size="small"
+            onClick={() => setIsExpanded(!isExpanded)}
+            aria-label={isExpanded ? 'Collapse logs' : 'Expand logs'}
+          >
+            {isExpanded ? <ChevronDown16 /> : <ChevronUp16 />}
+          </Button>
+        </div>
+
+        {isExpanded ? (
+          logs.length > 0 ? (
+            <ScrollArea ref={scrollRef} className="flex-1">
+              <table className="w-full border-collapse font-mono text-xs relative">
+                <thead>
+                  <tr
+                    className={cx('z-10 text-xs sticky top-0', [
+                      'bg-white dark:bg-graydark-200',
+                      'shadow-border-b shadow-gray-400 dark:shadow-graydark-400',
+                    ])}
+                  >
+                    <th className="px-2 py-1.5 text-left font-medium">Time</th>
+                    <th className="px-2 py-1.5 text-left font-medium">Level</th>
+                    <th className="px-2 py-1.5 text-left font-medium">
+                      Source
+                    </th>
+                    <th className="px-2 py-1.5 text-left font-medium">
+                      Message
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {logs.map((log, i) => (
+                    <tr
+                      key={i}
+                      className={cx(
+                        'hover:bg-gray-200 dark:hover:bg-graydark-400',
+                        'transition-colors'
+                      )}
+                      onClick={() => copyToClipboard(log.raw, 'log')}
+                    >
+                      <td className="px-2 py-1 whitespace-nowrap opacity-50">
+                        {log.timestamp.toLocaleTimeString()}
+                      </td>
+                      <td
+                        className={`px-2 py-1 whitespace-nowrap font-semibold ${
+                          levelColors[log.level]
+                        }`}
+                      >
+                        {log.level}
+                      </td>
+                      <td className="px-2 py-1 whitespace-nowrap opacity-75">
+                        {log.source}
+                      </td>
+                      <td className="px-2 py-1">
+                        <div className="whitespace-pre">{log.message}</div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ScrollArea>
+          ) : (
+            <div className="flex flex-col h-full items-center justify-center">
+              <Text size="16" color="verySubtle">
+                No logs
+              </Text>
+            </div>
+          )
+        ) : null}
+      </Panel>
+    </div>
+  )
+}

--- a/renterd/renderer/components/useDaemon.tsx
+++ b/renterd/renderer/components/useDaemon.tsx
@@ -22,7 +22,7 @@ export function useDaemon() {
     if (error) {
       console.error(error)
       triggerErrorToast({
-        title: 'Error starting daemon',
+        title: error.message,
       })
     }
     await isRunning.mutate()
@@ -34,7 +34,7 @@ export function useDaemon() {
     if (error) {
       console.error(error)
       triggerErrorToast({
-        title: `Error stopping daemon`,
+        title: error.message,
       })
     }
     await isRunning.mutate()

--- a/renterd/renderer/contexts/config/index.tsx
+++ b/renterd/renderer/contexts/config/index.tsx
@@ -110,7 +110,7 @@ function useConfigMain() {
       if (saveConfig.error) {
         console.error(saveConfig.error)
         triggerErrorToast({
-          title: 'Error saving settings',
+          title: saveConfig.error.message,
         })
         return
       }

--- a/renterd/renderer/renderer.d.ts
+++ b/renterd/renderer/renderer.d.ts
@@ -1,6 +1,14 @@
 import { Config } from './components/useConfigData'
 
 type MaybeError = { error?: Error }
+type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
+type DaemonLog = {
+  timestamp: Date
+  level: LogLevel
+  source: string
+  message: string
+  raw: string
+}
 
 export interface API {
   closeWindow: () => Promise<void>
@@ -14,6 +22,9 @@ export interface API {
   getDefaultDataDirectory: () => Promise<string>
   getInstalledVersion: () => Promise<string>
   saveConfig: (config: Config) => Promise<MaybeError>
+  getDaemonLogs: () => Promise<DaemonLog[]>
+  clearDaemonLogs: () => Promise<boolean>
+  openLogFile: () => Promise<boolean>
 }
 
 declare global {

--- a/renterd/renderer/tsconfig.json
+++ b/renterd/renderer/tsconfig.json
@@ -28,7 +28,5 @@
     "../next.config.js",
     ".next/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/walletd/main/ipc.ts
+++ b/walletd/main/ipc.ts
@@ -14,6 +14,8 @@ import {
   saveConfig,
 } from './config'
 import { closeMainWindow } from './window'
+import { state } from './state'
+import path from 'path'
 
 export function initIpc() {
   ipcMain.handle('open-browser', (_, url: string) => {
@@ -39,7 +41,8 @@ export function initIpc() {
     return getIsConfigured()
   })
   ipcMain.handle('open-data-directory', () => {
-    shell.openPath(getDefaultDataPath())
+    const config = getConfig()
+    shell.openPath(config.directory)
     return true
   })
   ipcMain.handle('get-default-data-directory', async () => {
@@ -50,7 +53,21 @@ export function initIpc() {
     return getInstalledVersion()
   })
   ipcMain.handle('config-save', async (_, config: Config) => {
-    await saveConfig(config)
+    return saveConfig(config)
+  })
+  ipcMain.handle('get-daemon-logs', () => {
+    return state.daemonLogs
+  })
+  ipcMain.handle('clear-daemon-logs', () => {
+    state.daemonLogs = []
     return true
+  })
+  ipcMain.handle('open-log-file', () => {
+    const config = getConfig()
+    const logPath = path.join(config.directory, 'walletd.log')
+    if (fs.existsSync(logPath)) {
+      return shell.openPath(logPath)
+    }
+    return false
   })
 }

--- a/walletd/main/logs.ts
+++ b/walletd/main/logs.ts
@@ -1,0 +1,56 @@
+export type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
+
+export interface DaemonLog {
+  timestamp: Date
+  level: LogLevel
+  source: string
+  message: string
+  raw: string
+}
+
+function stripAnsiCodes(str: string): string {
+  // eslint-disable-next-line no-control-regex
+  return str.replace(/\x1B\[\d+m/g, '')
+}
+
+export function parseLogLine(line: string): DaemonLog | null {
+  try {
+    // Strip ANSI color codes
+    const cleanLine = stripAnsiCodes(line)
+
+    // Try to parse as structured log first
+    const parts = cleanLine.split(/\s+/)
+
+    // Check if it's a structured log (has timestamp and level)
+    if (parts[0]?.match(/^\d{4}-\d{2}-\d{2}T/)) {
+      if (parts.length < 4) return null
+
+      const timestamp = parts[0]
+      const level = parts[1] as LogLevel
+      const source = parts[2]
+      const message = parts.slice(3).join(' ')
+
+      if (!['INFO', 'ERROR', 'WARN', 'DEBUG'].includes(level)) return null
+
+      return {
+        timestamp: new Date(timestamp),
+        level,
+        source: source.replace(/:$/, ''),
+        message,
+        raw: cleanLine,
+      }
+    }
+
+    // Handle error messages
+    return {
+      timestamp: new Date(),
+      level: 'ERROR',
+      source: 'daemon',
+      message: cleanLine,
+      raw: cleanLine,
+    }
+  } catch (e) {
+    console.error('Failed to parse log line:', e)
+    return null
+  }
+}

--- a/walletd/main/preload.ts
+++ b/walletd/main/preload.ts
@@ -17,4 +17,7 @@ contextBridge.exposeInMainWorld('electron', {
   getDefaultDataDirectory: () =>
     ipcRenderer.invoke('get-default-data-directory'),
   getInstalledVersion: () => ipcRenderer.invoke('get-installed-version'),
+  getDaemonLogs: () => ipcRenderer.invoke('get-daemon-logs'),
+  clearDaemonLogs: () => ipcRenderer.invoke('clear-daemon-logs'),
+  openLogFile: () => ipcRenderer.invoke('open-log-file'),
 })

--- a/walletd/main/startup.ts
+++ b/walletd/main/startup.ts
@@ -4,11 +4,14 @@ import { getConfig, getIsConfigured } from './config'
 import { state } from './state'
 import { env } from './env'
 
-export function startup() {
+export async function startup() {
   // If the app is already configured, start the daemon and open browser
   // and do not show the configuration window.
   if (getIsConfigured()) {
-    startDaemon()
+    const { error } = await startDaemon()
+    if (error) {
+      return
+    }
     state.mainWindow?.close()
     shell.openExternal(`http://${getConfig().http.address}`)
   }

--- a/walletd/main/state.ts
+++ b/walletd/main/state.ts
@@ -1,14 +1,25 @@
 import { ChildProcess } from 'child_process'
 import { BrowserWindow, Tray } from 'electron'
+import { DaemonLog } from './logs'
 
 export const state: {
   mainWindow: BrowserWindow | null
   tray: Tray | null
   daemon: ChildProcess | null
   isQuitting: boolean
+  daemonLogs: DaemonLog[]
 } = {
   mainWindow: null,
   tray: null,
   isQuitting: false,
   daemon: null,
+  daemonLogs: [],
+}
+
+export function addDaemonLog(log: DaemonLog) {
+  // Ensure there are never more than 1000 logs.
+  if (state.daemonLogs.length > 1000) {
+    state.daemonLogs.shift()
+  }
+  state.daemonLogs.push(log)
 }

--- a/walletd/renderer/components/App.tsx
+++ b/walletd/renderer/components/App.tsx
@@ -4,6 +4,7 @@ import { AppBackdrop, ScrollArea } from '@siafoundation/design-system'
 import { ConfigForm } from './ConfigForm'
 import { useConfig } from '../contexts/config'
 import { Header } from './Header'
+import { LogViewer } from './LogViewer'
 
 export function App() {
   const { onSubmit } = useConfig()
@@ -11,13 +12,14 @@ export function App() {
     <form onSubmit={onSubmit}>
       <AppBackdrop />
       <div className="flex flex-col w-full h-screen justify-center items-center">
-        <ScrollArea className="flex-1">
-          <div className="flex flex-col gap-3 w-full justify-center items-center pb-4">
+        <ScrollArea className="flex-1 [&>div>div]:!block">
+          <div className="flex flex-col gap-3 w-full justify-center items-center pb-14">
             <Header />
             <ConfigForm />
           </div>
         </ScrollArea>
       </div>
+      <LogViewer />
     </form>
   )
 }

--- a/walletd/renderer/components/LogViewer.tsx
+++ b/walletd/renderer/components/LogViewer.tsx
@@ -1,0 +1,232 @@
+'use client'
+
+import { useEffect, useRef, useState } from 'react'
+import {
+  Panel,
+  Button,
+  ScrollArea,
+  copyToClipboard,
+  Text,
+} from '@siafoundation/design-system'
+import {
+  Reset16,
+  ChevronUp16,
+  ChevronDown16,
+  Launch16,
+} from '@siafoundation/react-icons'
+import useSWR from 'swr'
+import { LogLevel } from '../../main/logs'
+import { cx } from 'class-variance-authority'
+
+const defaultHeight = 400
+const storageKey = 'logViewerHeight'
+
+const levelColors: Record<LogLevel, string> = {
+  INFO: 'text-green-500',
+  ERROR: 'text-red-500',
+  WARN: 'text-amber-500',
+  DEBUG: 'text-blue-500',
+}
+
+export function LogViewer() {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [height, setHeight] = useState(() => {
+    if (typeof window === 'undefined') return defaultHeight
+    const saved = window.localStorage.getItem(storageKey)
+    return saved ? parseInt(saved, 10) : defaultHeight
+  })
+  const [dragOffset, setDragOffset] = useState(0)
+  const scrollRef = useRef<HTMLDivElement>(null)
+  const dragRef = useRef<HTMLDivElement>(null)
+  const isDraggingRef = useRef(false)
+  const startYRef = useRef(0)
+  const startHeightRef = useRef(0)
+
+  const { data: logs = [], mutate } = useSWR(
+    'daemon-logs',
+    () => window.electron.getDaemonLogs(),
+    {
+      refreshInterval: 1000,
+    }
+  )
+
+  useEffect(() => {
+    if (scrollRef.current) {
+      scrollRef.current.scrollTop = scrollRef.current.scrollHeight
+    }
+  }, [logs])
+
+  useEffect(() => {
+    const handleMouseMove = (e: MouseEvent) => {
+      if (!isDraggingRef.current) return
+      const dy = startYRef.current - e.clientY
+      setDragOffset(dy)
+    }
+
+    const handleMouseUp = () => {
+      if (!isDraggingRef.current) return
+      isDraggingRef.current = false
+      document.body.style.cursor = 'default'
+
+      const newHeight = Math.min(
+        Math.max(200, startHeightRef.current + dragOffset),
+        window.innerHeight * 0.9
+      )
+      setHeight(newHeight)
+      window.localStorage.setItem(storageKey, String(newHeight))
+      setDragOffset(0)
+    }
+
+    document.addEventListener('mousemove', handleMouseMove)
+    document.addEventListener('mouseup', handleMouseUp)
+
+    return () => {
+      document.removeEventListener('mousemove', handleMouseMove)
+      document.removeEventListener('mouseup', handleMouseUp)
+    }
+  }, [dragOffset])
+
+  const startDragging = (e: React.MouseEvent) => {
+    e.preventDefault()
+    isDraggingRef.current = true
+    startYRef.current = e.clientY
+    startHeightRef.current = height
+    document.body.style.cursor = 'row-resize'
+  }
+
+  const clearLogs = async () => {
+    await window.electron.clearDaemonLogs()
+    mutate()
+  }
+
+  const openLogFile = async () => {
+    await window.electron.openLogFile()
+  }
+
+  const currentHeight = isExpanded ? height + dragOffset : 40
+
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-50"
+      style={{
+        height: currentHeight,
+        transition: isDraggingRef.current ? 'none' : 'height 0.3s ease',
+      }}
+    >
+      {isExpanded && (
+        <div
+          ref={dragRef}
+          className="absolute top-0 left-0 right-0 h-1 cursor-row-resize bg-gray-800 hover:bg-accent-500 transition-colors"
+          onMouseDown={startDragging}
+        />
+      )}
+      <Panel className="h-full flex flex-col rounded-b-none">
+        <div
+          className={`flex items-center gap-2 px-2 ${
+            isExpanded ? 'py-2' : 'py-1.5'
+          } select-none`}
+        >
+          <div className="text-sm font-medium">Logs</div>
+          <div className="flex-1" />
+          {isExpanded && (
+            <>
+              <Button
+                variant="gray"
+                size="small"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  clearLogs()
+                }}
+              >
+                <Reset16 />
+                clear view
+              </Button>
+              <Button
+                variant="gray"
+                size="small"
+                className="text-xs gap-1"
+                onClick={(e) => {
+                  e.stopPropagation()
+                  openLogFile()
+                }}
+              >
+                <Launch16 />
+                open file
+              </Button>
+            </>
+          )}
+          <div className="w-px h-3 bg-gray-800/50" />
+          <Button
+            variant="gray"
+            size="small"
+            onClick={() => setIsExpanded(!isExpanded)}
+            aria-label={isExpanded ? 'Collapse logs' : 'Expand logs'}
+          >
+            {isExpanded ? <ChevronDown16 /> : <ChevronUp16 />}
+          </Button>
+        </div>
+
+        {isExpanded ? (
+          logs.length > 0 ? (
+            <ScrollArea ref={scrollRef} className="flex-1">
+              <table className="w-full border-collapse font-mono text-xs relative">
+                <thead>
+                  <tr
+                    className={cx('z-10 text-xs sticky top-0', [
+                      'bg-white dark:bg-graydark-200',
+                      'shadow-border-b shadow-gray-400 dark:shadow-graydark-400',
+                    ])}
+                  >
+                    <th className="px-2 py-1.5 text-left font-medium">Time</th>
+                    <th className="px-2 py-1.5 text-left font-medium">Level</th>
+                    <th className="px-2 py-1.5 text-left font-medium">
+                      Source
+                    </th>
+                    <th className="px-2 py-1.5 text-left font-medium">
+                      Message
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {logs.map((log, i) => (
+                    <tr
+                      key={i}
+                      className={cx(
+                        'hover:bg-gray-200 dark:hover:bg-graydark-400',
+                        'transition-colors'
+                      )}
+                      onClick={() => copyToClipboard(log.raw, 'log')}
+                    >
+                      <td className="px-2 py-1 whitespace-nowrap opacity-50">
+                        {log.timestamp.toLocaleTimeString()}
+                      </td>
+                      <td
+                        className={`px-2 py-1 whitespace-nowrap font-semibold ${
+                          levelColors[log.level]
+                        }`}
+                      >
+                        {log.level}
+                      </td>
+                      <td className="px-2 py-1 whitespace-nowrap opacity-75">
+                        {log.source}
+                      </td>
+                      <td className="px-2 py-1">
+                        <div className="whitespace-pre">{log.message}</div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </ScrollArea>
+          ) : (
+            <div className="flex flex-col h-full items-center justify-center">
+              <Text size="16" color="verySubtle">
+                No logs
+              </Text>
+            </div>
+          )
+        ) : null}
+      </Panel>
+    </div>
+  )
+}

--- a/walletd/renderer/components/useDaemon.tsx
+++ b/walletd/renderer/components/useDaemon.tsx
@@ -21,7 +21,9 @@ export function useDaemon() {
     const { error } = await window.electron.daemonStart()
     if (error) {
       console.error(error)
-      triggerErrorToast({ title: 'Error starting daemon' })
+      triggerErrorToast({
+        title: error.message,
+      })
     }
     await isRunning.mutate()
     setIsLoading(false)
@@ -32,7 +34,7 @@ export function useDaemon() {
     if (error) {
       console.error(error)
       triggerErrorToast({
-        title: `Error stopping daemon`,
+        title: error.message,
       })
     }
     await isRunning.mutate()

--- a/walletd/renderer/contexts/config/index.tsx
+++ b/walletd/renderer/contexts/config/index.tsx
@@ -92,7 +92,7 @@ function useConfigMain() {
       if (saveConfig.error) {
         console.error(saveConfig.error)
         triggerErrorToast({
-          title: 'Error saving settings',
+          title: saveConfig.error.message,
         })
         return
       }

--- a/walletd/renderer/next-env.d.ts
+++ b/walletd/renderer/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/walletd/renderer/renderer.d.ts
+++ b/walletd/renderer/renderer.d.ts
@@ -1,6 +1,14 @@
 import { Config } from './components/useConfigData'
 
 type MaybeError = { error?: Error }
+type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
+type DaemonLog = {
+  timestamp: Date
+  level: LogLevel
+  source: string
+  message: string
+  raw: string
+}
 
 export interface API {
   closeWindow: () => Promise<void>
@@ -14,6 +22,9 @@ export interface API {
   getDefaultDataDirectory: () => Promise<string>
   getInstalledVersion: () => Promise<string>
   saveConfig: (config: Config) => Promise<MaybeError>
+  getDaemonLogs: () => Promise<DaemonLog[]>
+  clearDaemonLogs: () => Promise<boolean>
+  openLogFile: () => Promise<boolean>
 }
 
 declare global {


### PR DESCRIPTION
### hostd
- Fixed config field name for syncer address.
### all
- There is now a log viewer in the configuration window.
- The log viewer has actions for toggling the viewer, clearing the log, opening the actual log file.
- The edge of the log viewer can be dragged to expand or shrink the viewer height.
- Error toasts now use the full error message.
- Errors generated in the UI are now also added to the logs in the log viewer for persistence and better visibility.

![Screenshot 2025-02-27 at 2.22.39 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/2222d36c-12e2-4fbd-8be6-9056feee59aa.png)

![Screenshot 2025-02-27 at 2.23.52 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/8df584fe-29f0-45f1-8d50-298fdb63469e.png)

![Screenshot 2025-02-27 at 2.22.05 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/b45d24c3-ac08-43b3-a2f8-203fb3fd1641.png)

![Screenshot 2025-02-27 at 2.22.16 PM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/2c52c716-ed60-4fdc-8c20-933cf5861e71.png)

