### PR TITLE
fix: daemon-specific log parsing

### DIFF
--- a/.changeset/small-lamps-applaud.md
+++ b/.changeset/small-lamps-applaud.md
@@ -1,0 +1,5 @@
+---
+'hostd': patch
+---
+
+Fixed an issue where configuration errors were not triggering a toast.

--- a/.changeset/twenty-ants-build.md
+++ b/.changeset/twenty-ants-build.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+Double-click to copy a log line.

--- a/.changeset/two-spoons-prove.md
+++ b/.changeset/two-spoons-prove.md
@@ -1,0 +1,7 @@
+---
+'renterd': minor
+'walletd': minor
+'hostd': minor
+---
+
+The exact log parsing was refined.

--- a/hostd/main/ipc.ts
+++ b/hostd/main/ipc.ts
@@ -53,8 +53,7 @@ export function initIpc() {
     return getInstalledVersion()
   })
   ipcMain.handle('config-save', async (_, config: Config) => {
-    await saveConfig(config)
-    return true
+    return saveConfig(config)
   })
   ipcMain.handle('get-daemon-logs', () => {
     return state.daemonLogs

--- a/hostd/renderer/components/LogViewer.tsx
+++ b/hostd/renderer/components/LogViewer.tsx
@@ -195,14 +195,14 @@ export function LogViewer() {
                         'hover:bg-gray-200 dark:hover:bg-graydark-400',
                         'transition-colors'
                       )}
-                      onClick={() => copyToClipboard(log.raw, 'log')}
+                      onDoubleClick={() => copyToClipboard(log.raw, 'log')}
                     >
                       <td className="px-2 py-1 whitespace-nowrap opacity-50">
-                        {log.timestamp.toLocaleTimeString()}
+                        {log.timestamp?.toLocaleTimeString()}
                       </td>
                       <td
                         className={`px-2 py-1 whitespace-nowrap font-semibold ${
-                          levelColors[log.level]
+                          log.level ? levelColors[log.level] : ''
                         }`}
                       >
                         {log.level}

--- a/hostd/renderer/renderer.d.ts
+++ b/hostd/renderer/renderer.d.ts
@@ -3,9 +3,9 @@ import { Config } from './components/useConfigData'
 type MaybeError = { error?: Error }
 type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
 type DaemonLog = {
-  timestamp: Date
-  level: LogLevel
-  source: string
+  timestamp?: Date
+  level?: LogLevel
+  source?: string
   message: string
   raw: string
 }

--- a/renterd/renderer/components/LogViewer.tsx
+++ b/renterd/renderer/components/LogViewer.tsx
@@ -195,14 +195,14 @@ export function LogViewer() {
                         'hover:bg-gray-200 dark:hover:bg-graydark-400',
                         'transition-colors'
                       )}
-                      onClick={() => copyToClipboard(log.raw, 'log')}
+                      onDoubleClick={() => copyToClipboard(log.raw, 'log')}
                     >
                       <td className="px-2 py-1 whitespace-nowrap opacity-50">
-                        {log.timestamp.toLocaleTimeString()}
+                        {log.timestamp?.toLocaleTimeString()}
                       </td>
                       <td
                         className={`px-2 py-1 whitespace-nowrap font-semibold ${
-                          levelColors[log.level]
+                          log.level ? levelColors[log.level] : ''
                         }`}
                       >
                         {log.level}

--- a/renterd/renderer/renderer.d.ts
+++ b/renterd/renderer/renderer.d.ts
@@ -3,9 +3,9 @@ import { Config } from './components/useConfigData'
 type MaybeError = { error?: Error }
 type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
 type DaemonLog = {
-  timestamp: Date
-  level: LogLevel
-  source: string
+  timestamp?: Date
+  level?: LogLevel
+  source?: string
   message: string
   raw: string
 }

--- a/walletd/renderer/components/LogViewer.tsx
+++ b/walletd/renderer/components/LogViewer.tsx
@@ -195,14 +195,14 @@ export function LogViewer() {
                         'hover:bg-gray-200 dark:hover:bg-graydark-400',
                         'transition-colors'
                       )}
-                      onClick={() => copyToClipboard(log.raw, 'log')}
+                      onDoubleClick={() => copyToClipboard(log.raw, 'log')}
                     >
                       <td className="px-2 py-1 whitespace-nowrap opacity-50">
-                        {log.timestamp.toLocaleTimeString()}
+                        {log.timestamp?.toLocaleTimeString()}
                       </td>
                       <td
                         className={`px-2 py-1 whitespace-nowrap font-semibold ${
-                          levelColors[log.level]
+                          log.level ? levelColors[log.level] : ''
                         }`}
                       >
                         {log.level}

--- a/walletd/renderer/renderer.d.ts
+++ b/walletd/renderer/renderer.d.ts
@@ -3,9 +3,9 @@ import { Config } from './components/useConfigData'
 type MaybeError = { error?: Error }
 type LogLevel = 'INFO' | 'ERROR' | 'WARN' | 'DEBUG'
 type DaemonLog = {
-  timestamp: Date
-  level: LogLevel
-  source: string
+  timestamp?: Date
+  level?: LogLevel
+  source?: string
   message: string
   raw: string
 }


### PR DESCRIPTION
- Fixed an issue where configuration errors were not triggering a toast.
- Double-click to copy a log line.
- The exact log parsing was refined.

### hostd, walletd, renterd
![Screenshot 2025-02-28 at 10.13.36 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/2da7d051-8a79-49da-bece-ecb88cdb547d.png)

![Screenshot 2025-02-28 at 10.12.51 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/96889f66-1215-458b-a4a7-a7858d8379f0.png)

![Screenshot 2025-02-28 at 10.11.10 AM.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/cleTojt8wre2nDvCJHng/2e54885b-7fc2-492b-aea2-16d598dd1975.png)

