### PR TITLE
fix(hostd): replace rhp2 and rhp3 fields with rhp4 post field

### DIFF
--- a/.changeset/honest-aliens-eat.md
+++ b/.changeset/honest-aliens-eat.md
@@ -1,0 +1,5 @@
+---
+'hostd': minor
+---
+
+RHP2 and RHP3 configuration fields have been replaced with a single RHP4 port field.

--- a/hostd/renderer/components/ConfigForm.tsx
+++ b/hostd/renderer/components/ConfigForm.tsx
@@ -73,10 +73,7 @@ export function ConfigForm() {
             </div>
             <div className="flex gap-2">
               <div className="flex-1">
-                <FieldText form={form} fields={fields} name="rhp2Address" />
-              </div>
-              <div className="flex-1">
-                <FieldText form={form} fields={fields} name="rhp3AddressTcp" />
+                <FieldText form={form} fields={fields} name="rhp4Port" />
               </div>
             </div>
             <div className="pt-2 pb-1">

--- a/hostd/renderer/components/useConfigData.tsx
+++ b/hostd/renderer/components/useConfigData.tsx
@@ -17,11 +17,8 @@ export type Config = {
   log: {
     level: string
   }
-  rhp2: {
-    address: string
-  }
-  rhp3: {
-    tcp: string
+  rhp4: {
+    listenAddresses: { protocol: string; address: string }[]
   }
 }
 
@@ -33,6 +30,6 @@ export function useConfigData() {
     },
     {
       refreshInterval: 10_000,
-    }
+    },
   )
 }

--- a/hostd/renderer/contexts/config/fields.tsx
+++ b/hostd/renderer/contexts/config/fields.tsx
@@ -125,17 +125,22 @@ export function getFields({
       placeholder: ':9981',
       validation: {},
     },
-    rhp2Address: {
+    rhp4Port: {
       type: 'text',
-      title: 'RHP2 address',
-      placeholder: ':9982',
-      validation: {},
-    },
-    rhp3AddressTcp: {
-      type: 'text',
-      title: 'RHP3 TCP address',
-      placeholder: ':9983',
-      validation: {},
+      title: 'RHP4 port',
+      placeholder: '9984',
+      validation: {
+        required: 'required',
+        validate: {
+          valid: (value) => {
+            const valid =
+              /^\d+$/.test(value as string) &&
+              Number(value) >= 1 &&
+              Number(value) <= 65535
+            return valid || 'should be a number between 1 and 65535'
+          },
+        },
+      },
     },
     logLevel: {
       type: 'text',

--- a/hostd/renderer/contexts/config/transform.ts
+++ b/hostd/renderer/contexts/config/transform.ts
@@ -10,6 +10,13 @@ export function transformDown({
   config: Config
   defaultDataPath: string
 }): ConfigValues {
+  // Get port from the first listen address.
+  // All RHP4 listen addresses must have the same port.
+  const rhp4ListenAddress =
+    config.rhp4.listenAddresses.find((address) => address.protocol === 'tcp')
+      ?.address || ''
+  const rhp4Port = rhp4ListenAddress.split(':')[1] || ''
+
   return {
     name: config.name,
     dataDir: config.directory || defaultDataPath,
@@ -18,8 +25,7 @@ export function transformDown({
     httpAddress: config.http.address,
     httpPassword: config.http.password,
     syncerAddress: config.syncer.address,
-    rhp2Address: config.rhp2.address,
-    rhp3AddressTcp: config.rhp3.tcp,
+    rhp4Port,
     logLevel: config.log.level,
   }
 }
@@ -37,9 +43,11 @@ export function transformUp(data: ConfigValues): Config {
     syncer: {
       address: data.syncerAddress,
     },
-    rhp2: { address: data.rhp2Address },
-    rhp3: {
-      tcp: data.rhp3AddressTcp,
+    rhp4: {
+      listenAddresses: [
+        { protocol: 'tcp', address: `:${data.rhp4Port}` },
+        { protocol: 'quic', address: `:${data.rhp4Port}` },
+      ],
     },
     log: {
       level: data.logLevel,

--- a/hostd/renderer/contexts/config/types.ts
+++ b/hostd/renderer/contexts/config/types.ts
@@ -6,8 +6,7 @@ export const defaultValues = {
   httpAddress: 'localhost:9980',
   httpPassword: '',
   syncerAddress: ':9981',
-  rhp2Address: ':9982',
-  rhp3AddressTcp: ':9983',
+  rhp4Port: '9984',
   logLevel: 'info',
 }
 


### PR DESCRIPTION
- RHP2 and RHP3 configuration fields have been replaced with a single RHP4 port field.
    - RHP2 and RHP3 was removed in the latest version of hostd.

![Screenshot 2025-08-28 at 10.08.37 AM.png](https://app.graphite.dev/user-attachments/assets/6b2c82b0-e239-4d71-a9f3-68b501a5d87f.png)

